### PR TITLE
Phase 3 (step 2): Equation of Time (21), Parallax (29) & re-anchor chapter numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 1.6.0 — Phase 3 (step 2): Equation of Time, Parallax, and edition re-anchoring
+
+This release adds **Chapter 21** (Equation of Time) and **Chapter 29** (Correction for Parallax), and
+re-anchors the project's chapter numbering to the actual 39-chapter reference edition. The suite
+grows from 94 to 102 tests, all passing.
+
+### New features
+
+- **Chapter 21 — Equation of Time.** `equationOfTime(jd)` returns the value in minutes of time from
+  W. M. Smart's self-contained series (formula 21.1), built on the Chapter-18 solar elements. The
+  static `equationOfTimeFromApparentValues(θ₀, αSun, ΔT)` reproduces the A.E.-based form at the head
+  of the chapter. Validated on Examples 21.a (−11ᵐ09.7ˢ) and 21.b (−11ᵐ10.3ˢ).
+- **Chapter 29 — Correction for Parallax.** New `ParallaxCorrection` static utility:
+  `parallaxFromDistanceInDegrees` (29.1), the rigorous `topocentric` (29.2/29.3, required for the
+  Moon) and the non-rigorous `topocentricApproximate` (29.4/29.5). Plus the Moon convenience
+  `moonTopocentricEquatorialCoordinates(jd, observer, height, θ₀)`. Validated on Example 29.a (Mars,
+  both formula sets) and exercised at Moon-scale parallax.
+
+### Edition re-anchoring
+
+- The project's reference is the **39-chapter edition** of AFFC (ending at chapter 39, *Linear
+  Regression; Correlation*), not the 4th edition's 43-chapter numbering used in earlier docs. The two
+  agree for chapters 1–34; thereafter the docs are corrected: the phantom *Central Meridian of
+  Jupiter* is removed, and **Stellar Magnitudes 38→37**, **Binary Stars 39→38**, **Linear Regression
+  40→39**. *Atmospheric Refraction* and *Rising/Transit/Setting* are reclassified as **supplementary
+  utilities** beyond the reference edition (code unchanged); *Heliocentric Position of Pluto* is
+  dropped from the roadmap. Code comments and the coverage report / plan / refcard are updated;
+  immutable history (older CHANGELOG entries, past PR titles) keeps its original numbering.
+
+### Notes
+
+- The Moon rise/transit/set iterative refinement previously pencilled in for this step is dropped:
+  the reference edition has no Rising/Transit/Setting chapter, so there is no text to transcribe or
+  worked example to validate against. The first-approximation `RiseTransitSetCalculator` remains as a
+  supplementary utility.
+
 ## 1.5.0 — Phase 3 (step 1): Moon phenomena and Sun bonuses
 
 This release opens Phase 3 ("Harvest") with the first batch of derived Sun and Moon phenomena,

--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -1,7 +1,18 @@
 # EphemerisEngine vs. *Astronomical Formulae for Calculators* — Chapter-by-Chapter Coverage Report
 
-**Reference book:** Jean Meeus, *Astronomical Formulae for Calculators*, 4th edition (Willmann-Bell, 1988) — 43 chapters.
-**Library under review:** `com.nzv.astro:meeus-engine:1.5.0` (the EphemerisEngine project).
+**Reference book:** Jean Meeus, *Astronomical Formulae for Calculators* (Willmann-Bell) — the **39-chapter edition** used as this project's working reference, ending at chapter 39 (*Linear Regression; Correlation*).
+**Library under review:** `com.nzv.astro:meeus-engine:1.6.0` (the EphemerisEngine project).
+
+> **Edition & chapter-numbering note (since 1.6.0).** Earlier revisions of this report numbered the
+> later chapters against the *4th edition* (1988, 43 chapters). The project's working copy is an
+> **earlier 39-chapter edition**; the two agree exactly for chapters 1–34, then diverge. This report
+> is now re-anchored to the working edition: the 4th edition's *Central Meridian of Jupiter* (its
+> chapter 35) does not exist here, so the later chapters shift down by one — *Positions of the
+> Satellites of Jupiter* 35, *Semidiameters* 36, *Stellar Magnitudes* 37, *Binary Stars* 38,
+> *Linear Regression; Correlation* 39. The 4th edition's *Atmospheric Refraction*, *Rising/Transit/
+> Setting* and *Heliocentric Position of Pluto* are not chapters of this edition; the first two are
+> nonetheless implemented and are listed below under **Supplementary utilities**. Immutable history
+> (CHANGELOG entries, past PR titles) keeps its original numbering.
 **What the gauge means:** percentage of each chapter's formulae that the library actually exposes as callable, finished computations. A chapter that only supplies *inputs* (e.g. mean elements) to a calculation the book carries to completion is scored partial, not full.
 
 > Gauge legend: `██████████` = fully implemented · `░░░░░░░░░░` = not implemented.
@@ -19,6 +30,13 @@
 > full coverage: **13 Bright Limb** (0% → 100%), **31 Illuminated Fraction** (0% → 100%),
 > **32 Phases of the Moon** (0% → 100%), **20 Equinoxes and Solstices** (0% → 100%) and
 > **19 Rectangular Coordinates of the Sun** (0% → 100%, of-date and reduced to a chosen equinox).
+>
+> **Version note (1.6.0):** Phase 3, step 2 is complete, and the report is re-anchored to the
+> 39-chapter working edition (see the edition note above). Two chapters move to full coverage:
+> **21 Equation of Time** (0% → 100%, the self-contained series plus the A.E.-based form) and
+> **29 Correction for Parallax** (15% → 100%, rigorous and non-rigorous topocentric reduction, with
+> a Moon convenience). The Moon rise/transit/set refinement once pencilled in here is dropped: the
+> reference edition has no Rising/Transit/Setting chapter.
 
 > **Version note (1.3.0):** Phase 2, step 1 (the star keystone) is complete.
 > **16 Apparent Place of a Star** moves 25% → 95%: proper motion, precession, nutation
@@ -34,22 +52,24 @@ calendar, coordinate and solar-position foundations**, plus precession, interpol
 refraction and the common positional utilities (angular separation, photometry,
 rise/transit/set) and the apparent place of a star. It still stops before most of the
 **physical-ephemeris payload**: the planets, comets and eclipses are absent — but the Moon's
-geocentric position (Chapter 30) is implemented via a table-driven series, and the first batch of
-derived Sun/Moon phenomena (bright limb 13, illuminated fraction 31, phases 32, equinoxes/solstices
-20, rectangular solar coordinates 19) is now complete.
+geocentric position (Chapter 30) is implemented via a table-driven series, the derived Sun/Moon
+phenomena (bright limb 13, illuminated fraction 31, phases 32, equinoxes/solstices 20, rectangular
+solar coordinates 19) are complete, and the equation of time (21) and the correction for parallax
+(29) have now been added.
 
 | Coverage band | Chapters | Count |
 |---|---|---|
-| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 38 Stellar Magnitudes · 41 Refraction | 20 |
-| **Partial (10–80%)** | 1 Hints · 29 Parallax · 40 Regression · 42 Rising/Transit/Setting | 4 |
-| **None (0%)** | 10–12, 17, 21–28, 33–37, 39, 43 | 19 |
+| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 21 Equation of Time · 29 Correction for Parallax · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 37 Stellar Magnitudes | 21 |
+| **Partial (10–80%)** | 1 Hints · 39 Linear Regression | 2 |
+| **None (0%)** | 10–12, 17, 22–28, 33–36, 38 | 16 |
 
-**Overall functional coverage: getting on for half the book**, now spanning the entire
+**Overall functional coverage: about half the book**, now spanning the entire
 foundational arc (Chapters 1–9) plus precession (14), nutation (15), the apparent place of
 a star (16), solar coordinates (18) and rectangular solar coordinates (19), equinoxes/solstices (20),
-the position of the Moon (30) and its derived phenomena — bright limb (13), illuminated fraction (31)
-and phases (32) — stellar magnitudes (38), refraction (41) and a strong partial on
-rising/transit/setting (42).
+the equation of time (21), the correction for parallax (29), the position of the Moon (30) and its
+derived phenomena — bright limb (13), illuminated fraction (31) and phases (32) — and stellar
+magnitudes (37), with atmospheric refraction and rising/transit/setting available as supplementary
+utilities beyond the reference edition.
 
 ---
 
@@ -77,7 +97,7 @@ rising/transit/setting (42).
 | 18 | Solar Coordinates | MEDIUM | `██████████` 100% |
 | 19 | Rectangular Coordinates of the Sun | MEDIUM | `██████████` 100% |
 | 20 | Equinoxes and Solstices | MEDIUM | `██████████` 100% |
-| 21 | Equation of Time | MEDIUM | `░░░░░░░░░░` 0% |
+| 21 | Equation of Time | MEDIUM | `██████████` 100% |
 | 22 | Equation of Kepler | MEDIUM | `░░░░░░░░░░` 0% |
 | 23 | Elements of the Planetary Orbits | MEDIUM | `░░░░░░░░░░` 0% |
 | 24 | Planets: Principal Perturbations | HIGH | `░░░░░░░░░░` 0% |
@@ -85,21 +105,25 @@ rising/transit/setting (42).
 | 26 | Parabolic Motion | MEDIUM | `░░░░░░░░░░` 0% |
 | 27 | Planets in Perihelion and Aphelion | MEDIUM | `░░░░░░░░░░` 0% |
 | 28 | Passages Through the Nodes | MEDIUM | `░░░░░░░░░░` 0% |
-| 29 | Correction for Parallax | MEDIUM | `█▌░░░░░░░░` 15% |
+| 29 | Correction for Parallax | MEDIUM | `██████████` 100% |
 | 30 | Position of the Moon | HIGH | `█████████░` 90% |
 | 31 | Illuminated Fraction of the Moon's Disk | LOW | `██████████` 100% |
 | 32 | Phases of the Moon | MEDIUM | `██████████` 100% |
 | 33 | Eclipses | HIGH | `░░░░░░░░░░` 0% |
 | 34 | Illuminated Fraction of the Disk of a Planet | MEDIUM | `░░░░░░░░░░` 0% |
-| 35 | Central Meridian of Jupiter | MEDIUM | `░░░░░░░░░░` 0% |
-| 36 | Positions of the Satellites of Jupiter | HIGH | `░░░░░░░░░░` 0% |
-| 37 | Semidiameters of Sun, Moon and Planets | LOW | `░░░░░░░░░░` 0% |
-| 38 | Stellar Magnitudes | LOW | `██████████` 100% |
-| 39 | Binary Stars | MEDIUM | `░░░░░░░░░░` 0% |
-| 40 | Linear Regression and Correlation | LOW | `█░░░░░░░░░` 10% |
-| 41 | Atmospheric Refraction | MEDIUM | `██████████` 100% |
-| 42 | Rising, Transit and Setting | MEDIUM | `████████░░` 80% |
-| 43 | Heliocentric Position of Pluto | MEDIUM | `░░░░░░░░░░` 0% |
+| 35 | Positions of the Satellites of Jupiter | HIGH | `░░░░░░░░░░` 0% |
+| 36 | Semidiameters of Sun, Moon and Planets | LOW | `░░░░░░░░░░` 0% |
+| 37 | Stellar Magnitudes | LOW | `██████████` 100% |
+| 38 | Binary Stars | MEDIUM | `░░░░░░░░░░` 0% |
+| 39 | Linear Regression and Correlation | LOW | `█░░░░░░░░░` 10% |
+
+**Supplementary utilities (beyond the reference edition).** Implemented from standard formulae; not
+chapters of the 39-chapter edition, so excluded from the per-chapter percentages above.
+
+| Utility | Complexity | Status |
+|---|---|---|
+| Atmospheric Refraction | MEDIUM | `██████████` implemented |
+| Rising, Transit and Setting (first approximation) | MEDIUM | `████████░░` implemented (constant-coordinate form) |
 
 ---
 
@@ -205,10 +229,10 @@ rising/transit/setting (42).
 **Applications.** Season boundaries; calendar and almanac work.
 **Coverage.** Implemented: `equinoxSolsticeJulianDay(year, Season)` iterates formula 20.2 on the Sun's apparent longitude until the correction falls below a fraction of a second. Validated on Example 20.a (September equinox 1979 at JD 2444140.137).
 
-### 21 — Equation of Time · Complexity: MEDIUM · `░░░░░░░░░░` 0%
-**Formulae.** Difference between apparent and mean solar time.
+### 21 — Equation of Time · Complexity: MEDIUM · `██████████` 100%
+**Formulae.** Difference between apparent and mean solar time, by the self-contained series (formula 21.1) and the A.E.-based relation.
 **Applications.** Sundials, the analemma, converting clock time to true solar time.
-**Coverage.** Not implemented, but now a short add: it follows directly from the Sun's mean longitude and the apparent right ascension already produced by Chapter 18.
+**Coverage.** Implemented: `equationOfTime(jd)` returns the value in minutes of time from the series built on the Chapter-18 solar elements; the static `equationOfTimeFromApparentValues(...)` reproduces the A.E.-based form. Validated on Examples 21.a (−11ᵐ09.7ˢ) and 21.b (−11ᵐ10.3ˢ).
 
 ### 22 — Equation of Kepler · Complexity: MEDIUM · `░░░░░░░░░░` 0%
 **Formulae.** Solving M = E − e·sin E for the eccentric anomaly (iteration), then the true anomaly and radius vector.
@@ -245,10 +269,10 @@ rising/transit/setting (42).
 **Applications.** Eclipse seasons; latitude-zero crossings.
 **Coverage.** Not implemented.
 
-### 29 — Correction for Parallax · Complexity: MEDIUM · `█▌░░░░░░░░` 15%
-**Formulae.** Convert geocentric to topocentric coordinates using the observer's ρ·sin φ′ / ρ·cos φ′ and the body's parallax; Earth–body distance from horizontal parallax.
+### 29 — Correction for Parallax · Complexity: MEDIUM · `██████████` 100%
+**Formulae.** Convert geocentric to topocentric coordinates using the observer's ρ·sin φ′ / ρ·cos φ′ and the body's parallax (rigorous 29.2/29.3 and non-rigorous 29.4/29.5); Earth–body distance from horizontal parallax (29.1).
 **Applications.** Moon and near-body positions as seen from a specific site; occultation/eclipse timing.
-**Coverage.** A helper is present — `earthDistanceToMoonInKilometers(parallax)` plus the Earth-radius constant — and the observer's ρ·sin φ′ / ρ·cos φ′ are now available from Chapter 6. The topocentric coordinate correction itself is still not implemented (a Phase 3 harvest item).
+**Coverage.** Implemented in `ParallaxCorrection`: `parallaxFromDistanceInDegrees`, the rigorous `topocentric` and the non-rigorous `topocentricApproximate`, plus the Moon convenience `moonTopocentricEquatorialCoordinates(jd, observer, height, θ₀)`. Validated on Example 29.a (Mars, both formula sets) and exercised at Moon-scale parallax.
 
 ### 30 — Position of the Moon · Complexity: HIGH · `██░░░░░░░░` 20%
 **Formulae.** Moon's mean elements (L′, M′, F, D, Ω) followed by long periodic series for longitude, latitude, and parallax → geocentric position and distance.
@@ -275,50 +299,37 @@ rising/transit/setting (42).
 **Applications.** Appearance of Venus/Mars; magnitude inputs.
 **Coverage.** Not implemented.
 
-### 35 — Central Meridian of Jupiter · Complexity: MEDIUM · `░░░░░░░░░░` 0%
-**Formulae.** Longitude of Jupiter's central meridian (Systems I/II).
-**Applications.** Timing transits of the Great Red Spot and other features.
-**Coverage.** Not implemented.
-
-### 36 — Positions of the Satellites of Jupiter · Complexity: HIGH · `░░░░░░░░░░` 0%
+### 35 — Positions of the Satellites of Jupiter · Complexity: HIGH · `░░░░░░░░░░` 0%
 **Formulae.** Apparent positions of the four Galilean moons.
 **Applications.** Identifying moons; predicting transits, eclipses, occultations of the satellites.
 **Coverage.** Not implemented.
 
-### 37 — Semidiameters of Sun, Moon and Planets · Complexity: LOW · `░░░░░░░░░░` 0%
+### 36 — Semidiameters of Sun, Moon and Planets · Complexity: LOW · `░░░░░░░░░░` 0%
 **Formulae.** Apparent angular radius from distance.
 **Applications.** Rise/set refinement, eclipse and occultation geometry, sizing for drawings.
 **Coverage.** Not implemented.
 
-### 38 — Stellar Magnitudes · Complexity: LOW · `██████████` 100%
+### 37 — Stellar Magnitudes · Complexity: LOW · `██████████` 100%
 **Formulae.** Pogson's relation; combining magnitudes; brightness ratios.
 **Applications.** Variable-star work; combined brightness of close pairs; limiting-magnitude estimates.
 **Coverage.** *Implemented in 1.2.0.* `StellarMagnitudes` provides Pogson's ratio, the brightness ratio for a magnitude difference and its inverse, and the combined magnitude of two or more bodies (matches the double-star example, combined 1.96 + 2.89 → 1.58).
 
-### 39 — Binary Stars · Complexity: MEDIUM · `░░░░░░░░░░` 0%
+### 38 — Binary Stars · Complexity: MEDIUM · `░░░░░░░░░░` 0%
 **Formulae.** Apparent orbit of a visual binary from its elements (a Kepler-equation problem) → separation and position angle at a date.
 **Applications.** Ephemerides for double-star observers.
-**Coverage.** Not implemented (needs a Kepler solver; the position-angle/separation output side can reuse Chapter 9).
+**Coverage.** Not implemented (needs a Kepler solver from Chapter 22; the position-angle/separation output side can reuse Chapter 9). Slated for Phase 3, step 3.
 
-### 40 — Linear Regression and Correlation · Complexity: LOW · `█░░░░░░░░░` 10%
+### 39 — Linear Regression and Correlation · Complexity: LOW · `█░░░░░░░░░` 10%
 **Formulae.** Least-squares straight-line fit and the correlation coefficient.
 **Applications.** Reducing observation series; trend fitting.
-**Coverage.** Not exposed directly; the Apache Commons Math dependency could supply it, and the interpolation module offers Lagrange/Laguerre fitting, but regression itself is not part of the public API.
+**Coverage.** Not exposed directly; the Apache Commons Math dependency could supply it, and the interpolation module offers Lagrange/Laguerre fitting, but regression itself is not part of the public API. This is the final chapter of the reference edition.
 
-### 41 — Atmospheric Refraction · Complexity: MEDIUM · `██████████` 100%
-**Formulae.** True⇄apparent elevation, with optional temperature and pressure corrections.
-**Applications.** Correcting observed altitudes; rise/set timing; sextant sight reduction.
-**Coverage.** Fully implemented by `AtmosphericRefractionCalculator`, in both directions and with conditions (default 10 °C, 1013 mbar), guarding negative elevations.
+### Supplementary utilities (beyond the reference edition)
+These are implemented from standard formulae and are not chapters of the 39-chapter reference edition; they are therefore excluded from the per-chapter coverage above.
 
-### 42 — Rising, Transit and Setting · Complexity: MEDIUM · `████████░░` 80%
-**Formulae.** Local hour angle, and the times a body rises, transits, and sets (iterative, with refraction at the horizon).
-**Applications.** Sun/Moon/planet/star rise–set tables; observation windows.
-**Coverage.** *Implemented in 1.2.0.* `RiseTransitSetCalculator` returns rise/transit/set times (UT), rise/set azimuths, transit altitude, and circumpolar / never-rises flags, with selectable standard altitudes for stars/planets and the Sun. It uses the first-approximation form (apparent RA/Dec held constant over the day): exact for stars and accurate to a few minutes for the Sun (validated against the Sun from Uccle on 1978-11-13). The remaining 20% is the iterative refinement that interpolates a fast body's position across the day — most relevant for the Moon.
+**Atmospheric Refraction · `██████████` implemented.** True⇄apparent elevation with optional temperature and pressure corrections. Fully implemented by `AtmosphericRefractionCalculator`, in both directions and with conditions (default 10 °C, 1013 mbar), guarding negative elevations.
 
-### 43 — Heliocentric Position of Pluto · Complexity: MEDIUM · `░░░░░░░░░░` 0%
-**Formulae.** Pluto's heliocentric coordinates from a dedicated periodic series (the chapter added in the 4th edition).
-**Applications.** Locating Pluto.
-**Coverage.** Not implemented.
+**Rising, Transit and Setting · `████████░░` implemented (first approximation).** `RiseTransitSetCalculator` returns rise/transit/set times (UT), rise/set azimuths, transit altitude, and circumpolar / never-rises flags, with selectable standard altitudes for stars/planets and the Sun. It uses the first-approximation form (apparent RA/Dec held constant over the day): exact for stars and accurate to a few minutes for the Sun (validated against the Sun from Uccle on 1978-11-13). The iterative refinement for a fast body such as the Moon is not pursued, as the reference edition has no corresponding chapter.
 
 ---
 
@@ -326,13 +337,12 @@ rising/transit/setting (42).
 
 With Phase 1 complete, the picture has shifted. First, the **foundational arc is now
 unbroken**: Chapters 1–9 are all strong, and the three companion chapters the foundation
-leans on (14 Precession, 15 Nutation, 18 Solar Coordinates) are done, as are 38 and 41.
+leans on (14 Precession, 15 Nutation, 18 Solar Coordinates) are done, as are Stellar Magnitudes (37) and the supplementary refraction utility.
 Second, the **two keystones are now de-risked**: Apparent Place of a Star (16) has three of
 its four ingredients in place (precession, nutation, and the Sun for aberration), and
 Position of the Moon (30) still needs its periodic series but sits on mean elements that are
-ready. Third, the **next cheap wins are clustered around the Sun**: Equation of Time (21),
-Equinoxes/Solstices (20) and Rectangular Coordinates of the Sun (19) are now short additions
-because the Sun's apparent longitude, anomaly and radius vector are available — natural
-candidates to fold into a later phase alongside the Moon and star keystones.
+ready. Third, the **Sun-adjacent harvest is now gathered**: Equation of Time (21), Equinoxes/Solstices
+(20) and Rectangular Coordinates of the Sun (19) have all been folded in, alongside the Moon and
+star keystones and the parallax reduction (29).
 
-*Notes on sourcing: chapter titles and order are from the 4th-edition table of contents; coverage and complexity are assessed against the EphemerisEngine source and its reference card. A handful of percentages (e.g. the partial Moon/observer/star chapters and the 80% on rising/transit/setting) are judgement calls about how much of each chapter's finished output the library actually produces.*
+*Notes on sourcing: chapter titles and order are from the working (39-chapter) edition's table of contents; coverage and complexity are assessed against the EphemerisEngine source and its reference card. A handful of percentages (e.g. the partial Moon/observer/star chapters and the 80% on rising/transit/setting) are judgement calls about how much of each chapter's finished output the library actually produces.*

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -10,7 +10,7 @@
 |---|---|---|---|
 | **1 — Enablers & quick wins** | ✅ **DONE (v1.2.0)** | 6, 9, 14, 18, 38, 42 | All shipped with regression tests; 43 → 63 tests. |
 | **2 — The two keystones** | ✅ **Done (v1.4.0)** | 16 ✅, 30 ✅ | Star keystone (16) and Moon keystone (30, table-driven series) both shipped. |
-| **3 — Harvest** | 🟦 In progress — step 1 ✅ (v1.5.0) | 13 ✅, 19 ✅, 20 ✅, 31 ✅, 32 ✅ · then 29, 21, 22, 39 | Step 1 (Moon phenomena + Sun bonuses 19/20) shipped, 82 → 94 tests. Steps 2–3 next. |
+| **3 — Harvest** | 🟦 In progress — steps 1–2 ✅ (v1.5.0, v1.6.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 29 ✅, 31 ✅, 32 ✅ · then 22, 38 | Steps 1–2 shipped (Moon phenomena, Sun bonuses, parallax, equation of time), 82 → 96 tests. Step 3 (Kepler + binary stars) next. |
 | *Deferred* | ⬜ Out of scope | 23–28, 34–36, 43 | Planetary suite. |
 
 **What changed in v1.2.0 (Phase 1):**
@@ -38,11 +38,11 @@ Chapters positioned by implementation effort against value (with the Moon and st
 | | **Low effort** | **High effort** |
 |---|---|---|
 | **High value** | **Quick wins** — 18 Solar coordinates ✅ · 9 Angular separation ✅ · 42 Rising/transit/setting ✅ · 38 Stellar magnitudes ✅ · 6 Observer coordinates ✅ · 14 Precession ✅ | **Big bets** — 30 Position of the Moon ★★ ✅ · 16 Apparent place of a star ★★ ✅ · 33 Eclipses |
-| **Low value** | **Fill-ins** — 31 Illuminated fraction (Moon) · 32 Phases of the Moon · 13 Bright-limb angle · 29 Parallax (topocentric Moon) · 21 Equation of time | **Defer** — 39 Binary stars · 22 Equation of Kepler · 23+ Planetary suite (Ch 23–28, 34–36, 43) |
+| **Low value** | **Fill-ins** — 31 Illuminated fraction ✅ · 32 Phases of the Moon ✅ · 13 Bright-limb angle ✅ · 29 Parallax ✅ · 21 Equation of time ✅ | **Defer** — 38 Binary stars · 22 Equation of Kepler · 23+ Planetary suite (Ch 23–28, 34–36) |
 
 ★★ = the two keystones.
 
-Track legend: Moon track = Ch 13, 29, 30 ✅, 31, 32 · Star track = Ch 9 ✅, 14 ✅, 16 ✅, 38 ✅, 39 · Shared/deferred = Ch 18 ✅, 21, 22, 23+, 33, 42 ✅, 6 ✅.
+Track legend: Moon track = Ch 13 ✅, 29 ✅, 30 ✅, 31 ✅, 32 ✅ · Star track = Ch 9 ✅, 14 ✅, 16 ✅, 37 ✅ (stellar magnitudes), 38 (binary stars) · Shared/Sun = Ch 18 ✅, 19 ✅, 20 ✅, 21 ✅, 22, 23+, 33, 6 ✅ · rising/transit/setting available as a supplementary utility ✅.
 
 ---
 
@@ -79,8 +79,8 @@ These are the marquee deliverables. Each is genuinely laborious, but Phase 1 has
 Each of these was "high effort" only because it presupposed a Moon or Sun position. With Phase 2 done they collapse to short, mostly geometric additions. Eclipses (Ch 33) are explicitly **out** of Phase 3; the planetary suite stays deferred.
 
 - ✅ **Step 1 — Moon phenomena + Sun bonuses (DONE, v1.5.0).** Ch 31 (illuminated fraction), Ch 13 (bright-limb position angle), Ch 32 (phases), plus the Sun-adjacent bonuses Ch 20 (equinoxes & solstices) and Ch 19 (rectangular coordinates of the Sun, of-date and reduced to a chosen equinox). All five validated on their Meeus worked examples; suite 82 → 94 tests.
-- ⬜ **Step 2 — Parallax + Moon rise/transit/set + Equation of Time (v1.6.0).** Ch 29 (topocentric parallax, using Ch 6 ✅), the deferred iterative Moon rise/transit/set refinement, and the Sun bonus Ch 21 (Equation of Time).
-- ⬜ **Step 3 — Kepler + binary stars (v1.7.0).** Ch 22 (Equation of Kepler, hand-iterated — no external solver, keeping the build dependency-light) and Ch 39 (binary stars), whose separation/position-angle output reuses Ch 9 ✅.
+- ✅ **Step 2 — Parallax + Equation of Time (DONE, v1.6.0).** Ch 29 (topocentric parallax — rigorous and non-rigorous reduction plus a Moon convenience, using Ch 6 ✅) and the Sun bonus Ch 21 (Equation of Time). The Moon rise/transit/set refinement once planned here is **dropped**: re-anchoring to the working 39-chapter edition showed it has no Rising/Transit/Setting chapter, so there is no text to transcribe or worked example to validate against; the first-approximation calculator stays as a supplementary utility. This step also **re-anchored the project's chapter numbering** to the working edition (Stellar Magnitudes 38→37, Binary Stars 39→38, Linear Regression 40→39; the phantom Central Meridian of Jupiter removed; Refraction/RTS reclassified as supplementary, Pluto dropped).
+- ⬜ **Step 3 — Kepler + binary stars (v1.7.0).** Ch 22 (Equation of Kepler, hand-iterated — no external solver, keeping the build dependency-light) and Ch 38 (binary stars), whose separation/position-angle output reuses Ch 9 ✅.
 
 **Note on the true-vs-apparent longitude split:** within step 1, the elongation chapters (31, 13) use the Sun's *true* longitude, while equinoxes/solstices (20) use the *apparent* longitude — the apparent place is what defines the season. Mixing these up is a silent error, so it is called out in the findings log.
 
@@ -92,7 +92,7 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 
 **Effort is dominated by data entry and verification, not algorithm design.** The lunar and solar series are long coefficient tables that must be transcribed exactly. Budget the time accordingly, and lean on the fact that Meeus prints a fully worked numerical example for nearly every chapter.
 
-**Make each chapter regression-proof before moving on.** The library ships a 94-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
+**Make each chapter regression-proof before moving on.** The library ships a 96-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
 
 ---
 
@@ -102,5 +102,5 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 |---|---|---|---|---|---|
 | **1** | Enablers & quick wins | 6, 9, 14, 18, 38, 42 | Low–medium | ✅ Done (v1.2.0) | The substrate for both keystones |
 | **2** | The two keystones | 16 ✅, 30 ✅ | High | ✅ Done (v1.4.0) | Both priority tracks' hard core |
-| **3** | Harvest (3 steps) | step 1: 13 ✅ 19 ✅ 20 ✅ 31 ✅ 32 ✅ · then 29, 21, 22, 39 | Low (post-keystone) | 🟦 Step 1 done (v1.5.0) | The derived Moon and star phenomena |
+| **3** | Harvest (3 steps) | steps 1–2: 13 ✅ 19 ✅ 20 ✅ 21 ✅ 29 ✅ 31 ✅ 32 ✅ · then 22, 38 | Low (post-keystone) | 🟦 Steps 1–2 done (v1.5.0, v1.6.0) | The derived Moon and star phenomena |
 | *Deferred* | Planetary suite | 23–28, 34–36, 43 | High | ⬜ | (Out of scope for a Moon/star focus) |

--- a/REFCARD.md
+++ b/REFCARD.md
@@ -303,7 +303,7 @@ double pa  = AngularSeparation.positionAngle(arcturus, spica);    // 203.308°
 ## 11. Stellar Magnitudes — `StellarMagnitudes` (static)
 
 `com.nzv.astro.ephemeris.StellarMagnitudes`. Pogson's relation and combined magnitudes
-(Chapter 38).
+(Chapter 37).
 
 | Member | Returns |
 |---|---|
@@ -322,7 +322,7 @@ double dm       = StellarMagnitudes.magnitudeDifference(100.0);     // 5.0
 
 ## 12. Rising, Transit & Setting — `RiseTransitSetCalculator`
 
-`com.nzv.astro.ephemeris.RiseTransitSetCalculator` → returns `RiseTransitSet` (Chapter 42).
+`com.nzv.astro.ephemeris.RiseTransitSetCalculator` → returns `RiseTransitSet` (supplementary utility — not a chapter of the reference edition).
 First-approximation method: the body's apparent RA/Dec are treated as constant over the
 day (exact for stars, a good estimate for Sun/planets). Body RA in **degrees**, observer
 longitude positive **west**, Greenwich apparent sidereal time in **hours**. Times are UT
@@ -428,7 +428,7 @@ engine.moonEquatorialHorizontalParallaxe(T);//    0.930249° (book 0.930249)
 
 ---
 
-## 15. Moon & Sun Phenomena — `EphemerisEngine` (Ch. 31, 13, 32, 20, 19)
+## 15. Moon & Sun Phenomena — `EphemerisEngine` (Ch. 31, 13, 32, 20, 19, 21, 29)
 
 Derived phenomena built on the Sun (Ch. 18) and Moon (Ch. 30) positions. All angles in degrees;
 phase/equinox methods return a Julian Ephemeris Day.
@@ -443,6 +443,8 @@ phase/equinox methods return a Julian Ephemeris Day.
 | `moonPhaseJulianDay(year, MoonPhase)` | JDE of the New/First/Full/Last phase nearest `year` (Ch. 32). |
 | `sunRectangularEquatorialCoordinates(jd)` | `double[]{X,Y,Z}` (AU), mean equinox of date (Ch. 19). |
 | `sunRectangularEquatorialCoordinates(jd, equinox)` | `double[]{X,Y,Z}` (AU), reduced to `equinox` (e.g. 1950.0). |
+| `equationOfTime(jd)` | equation of time in **minutes of time** (Ch. 21). |
+| `moonTopocentricEquatorialCoordinates(jd, observer, height, θ₀)` | Moon topocentric α/δ (deg) for an observer (Ch. 29). |
 
 ```java
 EphemerisEngine e = new EphemerisEngineImpl();
@@ -451,6 +453,17 @@ e.moonBrightLimbPositionAngle(jd);                          // χ ≈ 250.38° (
 e.equinoxSolsticeJulianDay(1979, Season.SEPTEMBER_EQUINOX); // 2444140.137  (book Example 20.a)
 e.moonPhaseJulianDay(1977.13, MoonPhase.NEW_MOON);          // 2443192.6525 (book Example 32.a)
 double[] xyz = e.sunRectangularEquatorialCoordinates(2443824.5, 1950.0); // {-0.65138, -0.68379, -0.29650}
+e.equationOfTime(2443529.5);                                // -11.171 min  (book -11m10.3s, Example 21.b)
+```
+
+Parallax reduction lives in the static `ParallaxCorrection` (Ch. 29):
+
+```java
+// rigorous topocentric reduction (use this form for the Moon)
+EquatorialCoordinates topo = ParallaxCorrection.topocentric(alphaDeg, deltaDeg, parallaxDeg,
+        rhoSinPhiPrime, rhoCosPhiPrime, hourAngleDeg);
+ParallaxCorrection.topocentricApproximate(...);             // non-rigorous (Sun/planets/comets)
+ParallaxCorrection.parallaxFromDistanceInDegrees(0.3757);   // π from distance (AU), formula 29.1
 ```
 
 > **HOT TIP:** the elongation chapters (31, 13) use the Sun's **true** longitude
@@ -458,6 +471,10 @@ double[] xyz = e.sunRectangularEquatorialCoordinates(2443824.5, 1950.0); // {-0.
 > (`sunApparentLongitude`) — the apparent place is what defines the season. Two static helpers,
 > `EphemerisEngineImpl.phaseAngleFromCoordinates(...)` and `.brightLimbPositionAngle(...)`, expose
 > the pure geometry for validating against externally supplied (A.E.) coordinates.
+>
+> **HOT TIP (Ch. 29):** for the **Moon** always use the rigorous `topocentric` form — the
+> non-rigorous one can be off by tens of arcseconds. For the Sun, planets and comets either form is
+> fine. The geocentric hour angle is H = θ₀ − longitude(west) − α.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.nzv.astro</groupId>
 	<artifactId>meeus-engine</artifactId>
-	<version>1.5.0</version>
+	<version>1.6.0</version>
 	<packaging>jar</packaging>
 
 	<name>EphemerisEngine</name>

--- a/src/main/java/com/nzv/astro/ephemeris/EphemerisEngine.java
+++ b/src/main/java/com/nzv/astro/ephemeris/EphemerisEngine.java
@@ -338,4 +338,48 @@ public interface EphemerisEngine {
 	 */
 	public double moonPhaseJulianDay(double year, MoonPhase phase);
 
+
+	// =====================================================================
+	// Chapter 21 - Equation of Time
+	// =====================================================================
+
+	/**
+	 * Returns the equation of time for a given instant, expressed in
+	 * <b>minutes of time</b> (chapter 21). The equation of time is the
+	 * difference between the apparent (true) and mean Sun; a negative value
+	 * means the apparent Sun is behind the mean Sun. This implementation uses
+	 * the self-contained series (formula 21.1) built on the solar elements of
+	 * chapter 18, so no Astronomical Ephemeris look-up is required.
+	 *
+	 * @param julianDay the considered instant as Julian day.
+	 * @return the equation of time, in minutes of time.
+	 */
+	public double equationOfTime(double julianDay);
+
+	// =====================================================================
+	// Chapter 29 - Correction for Parallax
+	// =====================================================================
+
+	/**
+	 * Returns the Moon's topocentric apparent equatorial coordinates (right
+	 * ascension and declination, in degrees) as seen from a given observer
+	 * (chapter 29). The Moon's geocentric apparent position and equatorial
+	 * horizontal parallax are taken from chapter 30; the rigorous reduction
+	 * (formulae 29.2 and 29.3) is then applied.
+	 *
+	 * @param julianDay the considered instant as Julian day.
+	 * @param observer the observer's geographic coordinates (latitude in
+	 *            degrees, longitude positive west in degrees).
+	 * @param observerHeightInMeters the observer's height above sea level, in
+	 *            metres.
+	 * @param apparentSiderealTimeAtGreenwichInHours the apparent sidereal time at
+	 *            Greenwich for the instant, in hours (see
+	 *            {@link MeeusEphemeris}).
+	 * @return the Moon's topocentric apparent equatorial coordinates (right
+	 *         ascension in degrees, declination in degrees).
+	 */
+	public com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates moonTopocentricEquatorialCoordinates(
+			double julianDay, com.nzv.astro.ephemeris.coordinate.GeographicCoordinates observer,
+			double observerHeightInMeters, double apparentSiderealTimeAtGreenwichInHours);
+
 }

--- a/src/main/java/com/nzv/astro/ephemeris/ParallaxCorrection.java
+++ b/src/main/java/com/nzv/astro/ephemeris/ParallaxCorrection.java
@@ -1,0 +1,134 @@
+package com.nzv.astro.ephemeris;
+
+import static java.lang.Math.atan2;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.lang.Math.toDegrees;
+import static java.lang.Math.toRadians;
+
+import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
+
+/**
+ * Reduction of geocentric equatorial coordinates to topocentric coordinates
+ * (the correction for parallax), following chapter 29 of Jean Meeus'
+ * <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * <i>Geocentric</i> coordinates are as seen from the centre of the Earth;
+ * <i>topocentric</i> coordinates are as seen from the observer's place. The
+ * observer is described by the quantities &rho;&middot;sin&phi;&prime; and
+ * &rho;&middot;cos&phi;&prime; (chapter 6, available from
+ * {@link com.nzv.astro.ephemeris.coordinate.GeocentricCoordinates}), and the
+ * body by its equatorial horizontal parallax &pi; and geocentric hour angle.
+ * <p>
+ * Two reductions are offered: the rigorous one of formulae (29.2)/(29.3), which
+ * must be used for the Moon, and the simpler non-rigorous one of formulae
+ * (29.4)/(29.5), which is adequate for the Sun, planets and comets. All angles
+ * are in degrees.
+ */
+public final class ParallaxCorrection {
+
+	/**
+	 * The Sun's equatorial horizontal parallax at unit distance, 8&Prime;.794,
+	 * expressed in degrees (used in formula 29.1).
+	 */
+	private static final double SOLAR_PARALLAX_AT_UNIT_DISTANCE_DEG = 8.794d / 3600.0d;
+
+	private ParallaxCorrection() {
+		// Utility class: no instances.
+	}
+
+	/**
+	 * Returns the equatorial horizontal parallax of a body from its distance to
+	 * the Earth (formula 29.1), suitable for the Sun, planets and comets.
+	 *
+	 * @param distanceInAstronomicalUnits the body's distance to the Earth, in
+	 *            astronomical units.
+	 * @return the equatorial horizontal parallax, in degrees.
+	 */
+	public static double parallaxFromDistanceInDegrees(double distanceInAstronomicalUnits) {
+		return SOLAR_PARALLAX_AT_UNIT_DISTANCE_DEG / distanceInAstronomicalUnits;
+	}
+
+	/**
+	 * Reduces geocentric equatorial coordinates to topocentric ones using the
+	 * rigorous formulae (29.2) and (29.3). This is the form required for the
+	 * Moon.
+	 *
+	 * @param rightAscension the geocentric right ascension &alpha;, in degrees.
+	 * @param declination the geocentric declination &delta;, in degrees.
+	 * @param parallaxInDegrees the body's equatorial horizontal parallax &pi;, in
+	 *            degrees.
+	 * @param rhoSinPhiPrime the observer's &rho;&middot;sin&phi;&prime;
+	 *            (chapter 6).
+	 * @param rhoCosPhiPrime the observer's &rho;&middot;cos&phi;&prime;
+	 *            (chapter 6).
+	 * @param geocentricHourAngleInDegrees the body's geocentric hour angle H, in
+	 *            degrees.
+	 * @return the topocentric coordinates (right ascension normalised to
+	 *         [0, 360) degrees, declination in degrees).
+	 */
+	public static EquatorialCoordinates topocentric(double rightAscension, double declination,
+			double parallaxInDegrees, double rhoSinPhiPrime, double rhoCosPhiPrime,
+			double geocentricHourAngleInDegrees) {
+		double H = toRadians(geocentricHourAngleInDegrees);
+		double sinPi = sin(toRadians(parallaxInDegrees));
+		double delta = toRadians(declination);
+
+		// Parallax in right ascension (formula 29.2).
+		double numeratorAlpha = -rhoCosPhiPrime * sinPi * sin(H);
+		double denominator = cos(delta) - rhoCosPhiPrime * sinPi * cos(H);
+		double deltaAlpha = atan2(numeratorAlpha, denominator);
+
+		// Topocentric declination computed directly (formula 29.3).
+		double numeratorDelta = (sin(delta) - rhoSinPhiPrime * sinPi) * cos(deltaAlpha);
+		double deltaPrime = toDegrees(atan2(numeratorDelta, denominator));
+
+		double alphaPrime = normalizeDegrees(rightAscension + toDegrees(deltaAlpha));
+		return new EquatorialCoordinates(alphaPrime, deltaPrime);
+	}
+
+	/**
+	 * Reduces geocentric equatorial coordinates to topocentric ones using the
+	 * non-rigorous formulae (29.4) and (29.5). Adequate for the Sun, planets and
+	 * comets, but not for the Moon.
+	 *
+	 * @param rightAscension the geocentric right ascension &alpha;, in degrees.
+	 * @param declination the geocentric declination &delta;, in degrees.
+	 * @param parallaxInDegrees the body's equatorial horizontal parallax &pi;, in
+	 *            degrees.
+	 * @param rhoSinPhiPrime the observer's &rho;&middot;sin&phi;&prime;
+	 *            (chapter 6).
+	 * @param rhoCosPhiPrime the observer's &rho;&middot;cos&phi;&prime;
+	 *            (chapter 6).
+	 * @param geocentricHourAngleInDegrees the body's geocentric hour angle H, in
+	 *            degrees.
+	 * @return the topocentric coordinates (right ascension normalised to
+	 *         [0, 360) degrees, declination in degrees).
+	 */
+	public static EquatorialCoordinates topocentricApproximate(double rightAscension,
+			double declination, double parallaxInDegrees, double rhoSinPhiPrime,
+			double rhoCosPhiPrime, double geocentricHourAngleInDegrees) {
+		double H = toRadians(geocentricHourAngleInDegrees);
+		double delta = toRadians(declination);
+
+		// Formula (29.4): parallax in right ascension.
+		double deltaAlpha = -parallaxInDegrees * rhoCosPhiPrime * sin(H) / cos(delta);
+		// Formula (29.5): parallax in declination.
+		double deltaDelta = -parallaxInDegrees
+				* (rhoSinPhiPrime * cos(delta) - rhoCosPhiPrime * cos(H) * sin(delta));
+
+		double alphaPrime = normalizeDegrees(rightAscension + deltaAlpha);
+		return new EquatorialCoordinates(alphaPrime, declination + deltaDelta);
+	}
+
+	/**
+	 * Reduces an angle expressed in degrees to the range [0, 360).
+	 */
+	private static double normalizeDegrees(double degrees) {
+		double result = degrees % 360d;
+		if (result < 0) {
+			result += 360d;
+		}
+		return result;
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/RiseTransitSet.java
+++ b/src/main/java/com/nzv/astro/ephemeris/RiseTransitSet.java
@@ -2,8 +2,10 @@ package com.nzv.astro.ephemeris;
 
 /**
  * Holds the result of a rising / transit / setting computation for a celestial
- * body, as produced by {@link RiseTransitSetCalculator} (chapter 42 of Jean
- * Meeus' <i>Astronomical Formulae for Calculators</i>).
+ * body, as produced by {@link RiseTransitSetCalculator}. This is a supplementary
+ * utility built from the standard rising/transit/setting method; it is not one of
+ * the chapters of the reference edition of Meeus' <i>Astronomical Formulae for
+ * Calculators</i> used by this project.
  * <p>
  * All times are expressed as Universal Time in decimal hours in the range
  * [0, 24). When the body never crosses the chosen horizon the corresponding

--- a/src/main/java/com/nzv/astro/ephemeris/RiseTransitSetCalculator.java
+++ b/src/main/java/com/nzv/astro/ephemeris/RiseTransitSetCalculator.java
@@ -11,9 +11,10 @@ import com.nzv.astro.ephemeris.coordinate.GeographicCoordinates;
 import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
 
 /**
- * Computes the times of rising, upper transit and setting of a celestial body,
- * following chapter 42 of Jean Meeus' <i>Astronomical Formulae for
- * Calculators</i>.
+ * Computes the times of rising, upper transit and setting of a celestial body
+ * using the standard rising/transit/setting method. This is a supplementary
+ * utility: it is not one of the chapters of the reference edition of Meeus'
+ * <i>Astronomical Formulae for Calculators</i> used by this project.
  * <p>
  * This is the first-approximation form of the method: the body's apparent right
  * ascension and declination are treated as constant over the day. That is exact

--- a/src/main/java/com/nzv/astro/ephemeris/StellarMagnitudes.java
+++ b/src/main/java/com/nzv/astro/ephemeris/StellarMagnitudes.java
@@ -4,7 +4,7 @@ import static java.lang.Math.log10;
 import static java.lang.Math.pow;
 
 /**
- * Photometric relations between stellar magnitudes, following chapter 38 of Jean
+ * Photometric relations between stellar magnitudes, following chapter 37 of Jean
  * Meeus' <i>Astronomical Formulae for Calculators</i>: Pogson's relation, the
  * brightness ratio corresponding to a magnitude difference, and the combined
  * magnitude of two or more bodies.

--- a/src/main/java/com/nzv/astro/ephemeris/impl/EphemerisEngineImpl.java
+++ b/src/main/java/com/nzv/astro/ephemeris/impl/EphemerisEngineImpl.java
@@ -198,7 +198,7 @@ public class EphemerisEngineImpl implements EphemerisEngine {
 
 	@Override
 	public double sunRadiusVector(double T) {
-		double e = 0.01675104d - 0.0000418d * T - 0.000000126d * T * T;
+		double e = earthOrbitEccentricity(T);
 		double v = sunTrueAnomaly(T);
 		return (1.0000002d * (1 - e * e)) / (1 + e * cos(toRadians(v)));
 	}
@@ -540,6 +540,97 @@ public class EphemerisEngineImpl implements EphemerisEngine {
 				+ 0.0003d * sin(m + 2 * mp)
 				+ 0.0004d * sin(m - 2 * mp)
 				- 0.0003d * sin(2 * m + mp);
+	}
+
+
+	// =====================================================================
+	// Chapter 21 - Equation of Time
+	// =====================================================================
+
+	@Override
+	public double equationOfTime(double julianDay) {
+		double T = T(julianDay);
+		double epsilon = meanObliquityOfEcliptic(T);
+		double L = sunMeanLongitude(T);
+		double M = sunMeanAnomaly(T);
+		double e = earthOrbitEccentricity(T);
+		double y = Math.pow(tan(toRadians(epsilon / 2.0d)), 2);
+		double Lr = toRadians(L);
+		double Mr = toRadians(M);
+
+		// W. M. Smart's series (formula 21.1); E is obtained in radians.
+		double E = y * sin(2 * Lr)
+				- 2 * e * sin(Mr)
+				+ 4 * e * y * sin(Mr) * cos(2 * Lr)
+				- 0.5d * y * y * sin(4 * Lr)
+				- 1.25d * e * e * sin(2 * Mr);
+
+		// Radians -> degrees -> minutes of time (1 degree = 4 minutes of time).
+		return toDegrees(E) * 4.0d;
+	}
+
+	/**
+	 * Computes the equation of time (in minutes of time) from values that are
+	 * tabulated in the Astronomical Ephemeris, using the relation given at the
+	 * head of chapter 21. Exposed so the chapter's worked example, which feeds
+	 * A.E. values, can be reproduced exactly.
+	 *
+	 * @param apparentSiderealTimeAtGreenwich0hUTInHours apparent sidereal time at
+	 *            Greenwich for 0h UT, in hours.
+	 * @param sunApparentRightAscension0hETInHours the Sun's apparent right
+	 *            ascension at 0h ET, in hours.
+	 * @param deltaTInSeconds the difference ET - UT, in seconds.
+	 * @return the equation of time, in minutes of time.
+	 */
+	public static double equationOfTimeFromApparentValues(
+			double apparentSiderealTimeAtGreenwich0hUTInHours,
+			double sunApparentRightAscension0hETInHours, double deltaTInSeconds) {
+		double eHours = 12.0d + apparentSiderealTimeAtGreenwich0hUTInHours
+				- sunApparentRightAscension0hETInHours
+				- (0.002738d * deltaTInSeconds) / 3600.0d;
+		// The equation of time is small; fold the result into (-12, 12] hours so
+		// inputs straddling the 0h/24h boundary still give the right value.
+		eHours = eHours % 24.0d;
+		if (eHours > 12.0d) {
+			eHours -= 24.0d;
+		} else if (eHours < -12.0d) {
+			eHours += 24.0d;
+		}
+		return eHours * 60.0d;
+	}
+
+	// =====================================================================
+	// Chapter 29 - Correction for Parallax
+	// =====================================================================
+
+	@Override
+	public com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates moonTopocentricEquatorialCoordinates(
+			double julianDay, com.nzv.astro.ephemeris.coordinate.GeographicCoordinates observer,
+			double observerHeightInMeters, double apparentSiderealTimeAtGreenwichInHours) {
+		double T = T(julianDay);
+		com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates geocentric =
+				moonApparentEquatorialCoordinates(julianDay);
+		double alpha = geocentric.getRightAscension();
+		double delta = geocentric.getDeclinaison();
+		double parallax = moonEquatorialHorizontalParallaxe(T);
+
+		com.nzv.astro.ephemeris.coordinate.GeocentricCoordinates observerGeocentric =
+				new com.nzv.astro.ephemeris.coordinate.GeocentricCoordinates(
+						observer.getLatitude(), (float) observerHeightInMeters);
+
+		// Geocentric hour angle H = theta0 - longitude(west) - alpha, in degrees.
+		double H = apparentSiderealTimeAtGreenwichInHours * 15.0d - observer.getLongitude() - alpha;
+
+		return com.nzv.astro.ephemeris.ParallaxCorrection.topocentric(alpha, delta, parallax,
+				observerGeocentric.getRhoSinPhiPrime(), observerGeocentric.getRhoCosPhiPrime(), H);
+	}
+
+	/**
+	 * Returns the eccentricity of the Earth's orbit for a given instant
+	 * (chapter 18). Shared by the radius vector and the equation of time.
+	 */
+	private static double earthOrbitEccentricity(double T) {
+		return 0.01675104d - 0.0000418d * T - 0.000000126d * T * T;
 	}
 
 }

--- a/src/test/java/com/nzv/astro/ephemeris/impl/PhaseThreeStepTwoTest.java
+++ b/src/test/java/com/nzv/astro/ephemeris/impl/PhaseThreeStepTwoTest.java
@@ -1,0 +1,154 @@
+package com.nzv.astro.ephemeris.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.nzv.astro.ephemeris.ParallaxCorrection;
+import com.nzv.astro.ephemeris.coordinate.GeographicCoordinates;
+import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
+
+/**
+ * Tests for Phase 3, step 2 of the implementation plan: chapter 21 (equation of
+ * time) and chapter 29 (correction for parallax).
+ * <p>
+ * As elsewhere, each chapter is checked in two tiers: a loose comparison with
+ * the relevant Meeus worked example (the trustworthy anchor) and a pinned
+ * high-precision value (the regression anchor). Pure geometry is exercised with
+ * the book's own intermediate values so a transcription slip is isolated from a
+ * model difference.
+ */
+public class PhaseThreeStepTwoTest {
+
+	private static final double PIN = 1e-9;
+	private final EphemerisEngineImpl underTest = new EphemerisEngineImpl();
+
+	// =====================================================================
+	// Chapter 21 - Equation of Time
+	// =====================================================================
+
+	@Test
+	public void testChapter21Series() {
+		// Example 21.b: 1978 January 21 at 0h ET = JD 2443529.5, via the
+		// self-contained series (formula 21.1). Book: E = -11m 10.3s.
+		double e = underTest.equationOfTime(2443529.5d);
+		double bookMinutes = -(11 + 10.3d / 60.0d);
+		Assert.assertEquals(bookMinutes, e, 0.01d);
+		Assert.assertEquals(-11.171186178539639d, e, PIN);
+	}
+
+	@Test
+	public void testChapter21FromApparentValues() {
+		// Example 21.a: 1978 January 21 at 0h UT, from A.E. values:
+		// apparent sidereal time 8h00m01.193s, Sun apparent RA 20h11m10.78s,
+		// dT = +48.6s. Book: E = -11m 09.72s.
+		double theta0 = 8 + 1.193d / 3600.0d;
+		double sunRA = 20 + 11 / 60.0d + 10.78d / 3600.0d;
+		double e = EphemerisEngineImpl.equationOfTimeFromApparentValues(theta0, sunRA, 48.6d);
+		double bookMinutes = -(11 + 9.72d / 60.0d);
+		Assert.assertEquals(bookMinutes, e, 0.01d);
+		Assert.assertEquals(-11.162001113333309d, e, PIN);
+	}
+
+	@Test
+	public void testChapter21StaysWithinAnnualBounds() {
+		// The equation of time never leaves roughly +/-16.5 minutes; sample a few
+		// instants across a year as a sanity bound on the series.
+		double jd = 2443509.5d; // early 1978
+		for (int i = 0; i < 12; i++) {
+			double e = underTest.equationOfTime(jd + i * 30.0d);
+			Assert.assertTrue("equation of time out of bounds: " + e, Math.abs(e) < 17.0d);
+		}
+	}
+
+	// =====================================================================
+	// Chapter 29 - Correction for Parallax
+	// =====================================================================
+
+	@Test
+	public void testChapter29ParallaxFromDistance() {
+		// Example 29.a: Mars at 0.3757 AU has equatorial horizontal parallax
+		// pi = 8".794 / 0.3757 = 23".41 (formula 29.1).
+		double piArcsec = ParallaxCorrection.parallaxFromDistanceInDegrees(0.3757d) * 3600.0d;
+		Assert.assertEquals(23.41d, piArcsec, 0.01d);
+	}
+
+	@Test
+	public void testChapter29MarsRigorous() {
+		// Example 29.a (rigorous formulae 29.2/29.3), Uccle Observatory:
+		// alpha = 21h24m46.85s, delta = -22d24'09".9, pi = 23".41,
+		// rho.sin(phi') = +0.771306, rho.cos(phi') = +0.633333, H = +41.562 deg.
+		// Book topocentric: alpha' = 21h24m46.14s, delta' = -22d24'30".8.
+		double alpha = (21 + 24 / 60.0d + 46.85d / 3600.0d) * 15.0d;
+		double delta = -(22 + 24 / 60.0d + 9.9d / 3600.0d);
+		double pi = 23.41d / 3600.0d;
+		EquatorialCoordinates topo = ParallaxCorrection.topocentric(alpha, delta, pi, 0.771306d,
+				0.633333d, 41.562d);
+
+		double bookAlpha = (21 + 24 / 60.0d + 46.14d / 3600.0d) * 15.0d;
+		double bookDelta = -(22 + 24 / 60.0d + 30.8d / 3600.0d);
+		Assert.assertEquals(bookAlpha, topo.getRightAscension(), 5e-4d);
+		Assert.assertEquals(bookDelta, topo.getDeclinaison(), 5e-4d);
+		// Regression anchors.
+		Assert.assertEquals(321.19225282952004d, topo.getRightAscension(), PIN);
+		Assert.assertEquals(-22.40856158749298d, topo.getDeclinaison(), PIN);
+	}
+
+	@Test
+	public void testChapter29MarsApproximateMatchesRigorous() {
+		// For Mars the non-rigorous formulae (29.4/29.5) give the same result.
+		double alpha = (21 + 24 / 60.0d + 46.85d / 3600.0d) * 15.0d;
+		double delta = -(22 + 24 / 60.0d + 9.9d / 3600.0d);
+		double pi = 23.41d / 3600.0d;
+		EquatorialCoordinates approx = ParallaxCorrection.topocentricApproximate(alpha, delta, pi,
+				0.771306d, 0.633333d, 41.562d);
+		Assert.assertEquals(321.19225282952004d, approx.getRightAscension(), 5e-5d);
+		Assert.assertEquals(-22.40856158749298d, approx.getDeclinaison(), 5e-5d);
+		// Regression anchors.
+		Assert.assertEquals(321.1922530014444d, approx.getRightAscension(), PIN);
+		Assert.assertEquals(-22.40856151930152d, approx.getDeclinaison(), PIN);
+	}
+
+	@Test
+	public void testChapter29MoonNeedsRigorousFormulae() {
+		// The book's Moon exercise (fictive values, Uccle observer):
+		// alpha = 15 deg, delta = +5 deg, H = +60 deg, pi = 0d59'00".
+		// For the Moon the rigorous and non-rigorous results differ markedly,
+		// which is precisely why the chapter says to use the rigorous formulae.
+		double pi = 59.0d / 60.0d;
+		EquatorialCoordinates rigorous = ParallaxCorrection.topocentric(15.0d, 5.0d, pi, 0.771306d,
+				0.633333d, 60.0d);
+		EquatorialCoordinates approximate = ParallaxCorrection.topocentricApproximate(15.0d, 5.0d,
+				pi, 0.771306d, 0.633333d, 60.0d);
+		double deltaAlphaArcsec = Math
+				.abs(rigorous.getRightAscension() - approximate.getRightAscension()) * 3600.0d;
+		double deltaDeltaArcsec = Math
+				.abs(rigorous.getDeclinaison() - approximate.getDeclinaison()) * 3600.0d;
+		Assert.assertTrue("rigorous and approximate should differ for the Moon",
+				deltaAlphaArcsec > 5.0d && deltaDeltaArcsec > 5.0d);
+		// Regression anchors (rigorous).
+		Assert.assertEquals(14.455672132383134d, rigorous.getRightAscension(), PIN);
+		Assert.assertEquals(4.266643180630606d, rigorous.getDeclinaison(), PIN);
+	}
+
+	@Test
+	public void testChapter29MoonTopocentricConvenience() {
+		// End-to-end Moon topocentric position from Uccle (lat 50.7986, long
+		// 4.36 deg east), with an explicit apparent sidereal time. The
+		// topocentric position must differ from the geocentric one, but by no
+		// more than the Moon's horizontal parallax (about 0.93 deg here).
+		GeographicCoordinates uccle = new GeographicCoordinates(50.7986d, -4.3589d);
+		EquatorialCoordinates geocentric = underTest.moonApparentEquatorialCoordinates(2444214.5d);
+		EquatorialCoordinates topocentric = underTest.moonTopocentricEquatorialCoordinates(
+				2444214.5d, uccle, 105.0d, 6.0d);
+
+		double parallax = underTest.moonEquatorialHorizontalParallaxe(underTest.T(2444214.5d));
+		double dAlpha = Math.abs(topocentric.getRightAscension() - geocentric.getRightAscension());
+		double dDelta = Math.abs(topocentric.getDeclinaison() - geocentric.getDeclinaison());
+		Assert.assertTrue("topocentric should differ from geocentric", dAlpha > 1e-3 || dDelta > 1e-3);
+		Assert.assertTrue("shift cannot exceed the horizontal parallax",
+				dAlpha < parallax + 0.2d && dDelta < parallax + 0.2d);
+		// Regression anchors.
+		Assert.assertEquals(115.17408968280652d, topocentric.getRightAscension(), PIN);
+		Assert.assertEquals(17.734214368923983d, topocentric.getDeclinaison(), PIN);
+	}
+}


### PR DESCRIPTION
Adds Chapter 21 (Equation of Time — Smart's series plus the A.E.-based form) and Chapter 29 (Correction for Parallax — rigorous and non-rigorous topocentric reduction, with a Moon convenience). Re-anchors the project's chapter numbering to the actual 39-chapter reference edition: removes the phantom Central Meridian of Jupiter, renumbers Stellar Magnitudes 38→37 / Binary Stars 39→38 / Linear Regression 40→39, and reclassifies Refraction and Rising/Transit/Setting as supplementary utilities. Validated on Examples 21.a/21.b and 29.a; suite 94 → 102 tests; version 1.5.0 → 1.6.0