### PR TITLE
Phase 3 (step 3a): Chapter 22 — Equation of Kepler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.7.0 — Phase 3 (step 3a): Equation of Kepler
+
+This release adds **Chapter 22** (the equation of Kepler), the small transcendental solver that
+underpins elliptic motion and binary-star orbits. Chapter 38 (Binary Stars) follows in a later
+release. The suite grows from 102 to 108 tests, all passing.
+
+### New features
+
+- **Chapter 22 — Equation of Kepler.** New `KeplerEquation` static utility solving `E = M + e sin E`
+  for the eccentric anomaly, with all three methods of the chapter:
+  - `solveEccentricAnomaly(M, e)` / `solveEccentricAnomaly(M, e, tolerance)` — Newton's correction
+    (formula 22.3, the recommended method); converges quickly for every eccentricity.
+  - `solveEccentricAnomalyByIteration(M, e, tolerance)` — the simple fixed-point iteration (first
+    method); slow for large e.
+  - `approximateEccentricAnomaly(M, e)` — the closed-form approximation (formula 22.4), for small e.
+  All angles in degrees, using the "modified" eccentricity `e0 = e × 180/π` so the work stays in
+  degrees. No external dependency: the iteration is hand-coded.
+
+### Validation
+
+- Anchored on the chapter's worked examples: 22.a (e = 0.100, M = 5° → E = 5.554589 by iteration),
+  22.b (same data → E = 5.554589253 by Newton), the hard case e = 0.990, M = 2° → E = 32.361007,
+  and the closed-form approximation (E = 5.554599). Guard tests confirm E = M when e = 0 and that a
+  returned E satisfies Kepler's equation across a range of eccentricities and mean anomalies.
+
 ## 1.6.0 — Phase 3 (step 2): Equation of Time, Parallax, and edition re-anchoring
 
 This release adds **Chapter 21** (Equation of Time) and **Chapter 29** (Correction for Parallax), and

--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -1,7 +1,7 @@
 # EphemerisEngine vs. *Astronomical Formulae for Calculators* — Chapter-by-Chapter Coverage Report
 
 **Reference book:** Jean Meeus, *Astronomical Formulae for Calculators* (Willmann-Bell) — the **39-chapter edition** used as this project's working reference, ending at chapter 39 (*Linear Regression; Correlation*).
-**Library under review:** `com.nzv.astro:meeus-engine:1.6.0` (the EphemerisEngine project).
+**Library under review:** `com.nzv.astro:meeus-engine:1.7.0` (the EphemerisEngine project).
 
 > **Edition & chapter-numbering note (since 1.6.0).** Earlier revisions of this report numbered the
 > later chapters against the *4th edition* (1988, 43 chapters). The project's working copy is an
@@ -37,6 +37,11 @@
 > **29 Correction for Parallax** (15% → 100%, rigorous and non-rigorous topocentric reduction, with
 > a Moon convenience). The Moon rise/transit/set refinement once pencilled in here is dropped: the
 > reference edition has no Rising/Transit/Setting chapter.
+>
+> **Version note (1.7.0):** Phase 3, step 3a is complete. **22 Equation of Kepler** moves 0% → 100%:
+> the new `KeplerEquation` utility solves `E = M + e sin E` with all three methods of the chapter
+> (Newton's correction, the simple fixed-point iteration, and the closed-form approximation),
+> validated on Examples 22.a/22.b and the high-eccentricity case. Binary Stars (38) follows later.
 
 > **Version note (1.3.0):** Phase 2, step 1 (the star keystone) is complete.
 > **16 Apparent Place of a Star** moves 25% → 95%: proper motion, precession, nutation
@@ -59,14 +64,14 @@ solar coordinates 19) are complete, and the equation of time (21) and the correc
 
 | Coverage band | Chapters | Count |
 |---|---|---|
-| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 21 Equation of Time · 29 Correction for Parallax · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 37 Stellar Magnitudes | 21 |
+| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 21 Equation of Time · 22 Equation of Kepler · 29 Correction for Parallax · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 37 Stellar Magnitudes | 22 |
 | **Partial (10–80%)** | 1 Hints · 39 Linear Regression | 2 |
-| **None (0%)** | 10–12, 17, 22–28, 33–36, 38 | 16 |
+| **None (0%)** | 10–12, 17, 23–28, 33–36, 38 | 15 |
 
 **Overall functional coverage: about half the book**, now spanning the entire
 foundational arc (Chapters 1–9) plus precession (14), nutation (15), the apparent place of
 a star (16), solar coordinates (18) and rectangular solar coordinates (19), equinoxes/solstices (20),
-the equation of time (21), the correction for parallax (29), the position of the Moon (30) and its
+the equation of time (21), the equation of Kepler (22), the correction for parallax (29), the position of the Moon (30) and its
 derived phenomena — bright limb (13), illuminated fraction (31) and phases (32) — and stellar
 magnitudes (37), with atmospheric refraction and rising/transit/setting available as supplementary
 utilities beyond the reference edition.
@@ -98,7 +103,7 @@ utilities beyond the reference edition.
 | 19 | Rectangular Coordinates of the Sun | MEDIUM | `██████████` 100% |
 | 20 | Equinoxes and Solstices | MEDIUM | `██████████` 100% |
 | 21 | Equation of Time | MEDIUM | `██████████` 100% |
-| 22 | Equation of Kepler | MEDIUM | `░░░░░░░░░░` 0% |
+| 22 | Equation of Kepler | MEDIUM | `██████████` 100% |
 | 23 | Elements of the Planetary Orbits | MEDIUM | `░░░░░░░░░░` 0% |
 | 24 | Planets: Principal Perturbations | HIGH | `░░░░░░░░░░` 0% |
 | 25 | Elliptic Motion | HIGH | `░░░░░░░░░░` 0% |
@@ -234,10 +239,10 @@ chapters of the 39-chapter edition, so excluded from the per-chapter percentages
 **Applications.** Sundials, the analemma, converting clock time to true solar time.
 **Coverage.** Implemented: `equationOfTime(jd)` returns the value in minutes of time from the series built on the Chapter-18 solar elements; the static `equationOfTimeFromApparentValues(...)` reproduces the A.E.-based form. Validated on Examples 21.a (−11ᵐ09.7ˢ) and 21.b (−11ᵐ10.3ˢ).
 
-### 22 — Equation of Kepler · Complexity: MEDIUM · `░░░░░░░░░░` 0%
-**Formulae.** Solving M = E − e·sin E for the eccentric anomaly (iteration), then the true anomaly and radius vector.
-**Applications.** The heart of every elliptical-orbit position calculation.
-**Coverage.** Not implemented (general iterative solvers exist in the interpolation engine but Kepler's equation is not wired up).
+### 22 — Equation of Kepler · Complexity: MEDIUM · `██████████` 100%
+**Formulae.** Solving E = M + e·sin E for the eccentric anomaly by Newton's correction (22.3), the simple fixed-point iteration, and the closed-form approximation (22.4).
+**Applications.** The heart of every elliptical-orbit position calculation; needed for binary stars (38).
+**Coverage.** Implemented in `KeplerEquation`: `solveEccentricAnomaly` (Newton, recommended), `solveEccentricAnomalyByIteration` (first method) and `approximateEccentricAnomaly` (formula 22.4). Validated on Examples 22.a/22.b (E = 5.554589…) and the hard case e = 0.99, M = 2° (E = 32.361007).
 
 ### 23 — Elements of the Planetary Orbits · Complexity: MEDIUM · `░░░░░░░░░░` 0%
 **Formulae.** Mean orbital elements of the planets as polynomials in time.

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -10,7 +10,7 @@
 |---|---|---|---|
 | **1 — Enablers & quick wins** | ✅ **DONE (v1.2.0)** | 6, 9, 14, 18, 38, 42 | All shipped with regression tests; 43 → 63 tests. |
 | **2 — The two keystones** | ✅ **Done (v1.4.0)** | 16 ✅, 30 ✅ | Star keystone (16) and Moon keystone (30, table-driven series) both shipped. |
-| **3 — Harvest** | 🟦 In progress — steps 1–2 ✅ (v1.5.0, v1.6.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 29 ✅, 31 ✅, 32 ✅ · then 22, 38 | Steps 1–2 shipped (Moon phenomena, Sun bonuses, parallax, equation of time), 82 → 96 tests. Step 3 (Kepler + binary stars) next. |
+| **3 — Harvest** | 🟦 In progress — steps 1–2 ✅, 3a ✅ (v1.5.0–v1.7.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 22 ✅, 29 ✅, 31 ✅, 32 ✅ · then 38 | Steps 1–2 and 3a (equation of Kepler) shipped, 82 → 108 tests. Step 3b (binary stars, Ch 38) is the last Harvest item. |
 | *Deferred* | ⬜ Out of scope | 23–28, 34–36, 43 | Planetary suite. |
 
 **What changed in v1.2.0 (Phase 1):**
@@ -80,7 +80,8 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 
 - ✅ **Step 1 — Moon phenomena + Sun bonuses (DONE, v1.5.0).** Ch 31 (illuminated fraction), Ch 13 (bright-limb position angle), Ch 32 (phases), plus the Sun-adjacent bonuses Ch 20 (equinoxes & solstices) and Ch 19 (rectangular coordinates of the Sun, of-date and reduced to a chosen equinox). All five validated on their Meeus worked examples; suite 82 → 94 tests.
 - ✅ **Step 2 — Parallax + Equation of Time (DONE, v1.6.0).** Ch 29 (topocentric parallax — rigorous and non-rigorous reduction plus a Moon convenience, using Ch 6 ✅) and the Sun bonus Ch 21 (Equation of Time). The Moon rise/transit/set refinement once planned here is **dropped**: re-anchoring to the working 39-chapter edition showed it has no Rising/Transit/Setting chapter, so there is no text to transcribe or worked example to validate against; the first-approximation calculator stays as a supplementary utility. This step also **re-anchored the project's chapter numbering** to the working edition (Stellar Magnitudes 38→37, Binary Stars 39→38, Linear Regression 40→39; the phantom Central Meridian of Jupiter removed; Refraction/RTS reclassified as supplementary, Pluto dropped).
-- ⬜ **Step 3 — Kepler + binary stars (v1.7.0).** Ch 22 (Equation of Kepler, hand-iterated — no external solver, keeping the build dependency-light) and Ch 38 (binary stars), whose separation/position-angle output reuses Ch 9 ✅.
+- ✅ **Step 3a — Equation of Kepler (DONE, v1.7.0).** Ch 22 (Equation of Kepler) implemented as the `KeplerEquation` utility with all three methods of the chapter (Newton's correction, fixed-point iteration, closed-form approximation), hand-iterated with no external solver. Validated on Examples 22.a/22.b and the high-eccentricity case.
+- ⬜ **Step 3b — Binary stars (v1.8.0).** Ch 38 (binary stars), whose apparent-orbit solution reuses the Kepler solver just shipped and whose separation/position-angle output reuses Ch 9 ✅. The last Harvest item.
 
 **Note on the true-vs-apparent longitude split:** within step 1, the elongation chapters (31, 13) use the Sun's *true* longitude, while equinoxes/solstices (20) use the *apparent* longitude — the apparent place is what defines the season. Mixing these up is a silent error, so it is called out in the findings log.
 
@@ -92,7 +93,7 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 
 **Effort is dominated by data entry and verification, not algorithm design.** The lunar and solar series are long coefficient tables that must be transcribed exactly. Budget the time accordingly, and lean on the fact that Meeus prints a fully worked numerical example for nearly every chapter.
 
-**Make each chapter regression-proof before moving on.** The library ships a 96-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
+**Make each chapter regression-proof before moving on.** The library ships a 108-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
 
 ---
 
@@ -102,5 +103,5 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 |---|---|---|---|---|---|
 | **1** | Enablers & quick wins | 6, 9, 14, 18, 38, 42 | Low–medium | ✅ Done (v1.2.0) | The substrate for both keystones |
 | **2** | The two keystones | 16 ✅, 30 ✅ | High | ✅ Done (v1.4.0) | Both priority tracks' hard core |
-| **3** | Harvest (3 steps) | steps 1–2: 13 ✅ 19 ✅ 20 ✅ 21 ✅ 29 ✅ 31 ✅ 32 ✅ · then 22, 38 | Low (post-keystone) | 🟦 Steps 1–2 done (v1.5.0, v1.6.0) | The derived Moon and star phenomena |
+| **3** | Harvest | 13 ✅ 19 ✅ 20 ✅ 21 ✅ 22 ✅ 29 ✅ 31 ✅ 32 ✅ · then 38 | Low (post-keystone) | 🟦 Steps 1–2, 3a done (v1.5.0–v1.7.0) | The derived Moon and star phenomena |
 | *Deferred* | Planetary suite | 23–28, 34–36, 43 | High | ⬜ | (Out of scope for a Moon/star focus) |

--- a/REFCARD.md
+++ b/REFCARD.md
@@ -2,7 +2,7 @@
 
 ### The astronomical formulae of Jean Meeus, in Java
 
-> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
+> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Equation of Kepler &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
 
 ---
 
@@ -478,7 +478,33 @@ ParallaxCorrection.parallaxFromDistanceInDegrees(0.3757);   // π from distance 
 
 ---
 
-## 16. Constants — `Constants`
+## 16. Equation of Kepler — `KeplerEquation` (static, Ch. 22)
+
+`com.nzv.astro.ephemeris.KeplerEquation`. Solves `E = M + e sin E` for the eccentric anomaly *E*
+given the mean anomaly *M* and eccentricity *e*. All angles in degrees.
+
+| Method | Returns |
+|---|---|
+| `solveEccentricAnomaly(M, e)` | *E* (deg) by Newton's correction (22.3) — **recommended**, tol 1e-9°. |
+| `solveEccentricAnomaly(M, e, tol)` | as above, caller-supplied tolerance. |
+| `solveEccentricAnomalyByIteration(M, e, tol)` | *E* (deg) by fixed-point iteration (first method); slow for large *e*. |
+| `approximateEccentricAnomaly(M, e)` | *E* (deg) by the closed form (22.4); small *e* only. |
+
+```java
+KeplerEquation.solveEccentricAnomaly(5.0, 0.100);              // 5.554589253  (book Example 22.b)
+KeplerEquation.solveEccentricAnomalyByIteration(5.0, 0.100, 1e-6); // 5.554589 (book Example 22.a)
+KeplerEquation.solveEccentricAnomaly(2.0, 0.990);             // 32.361007    (hard case, Newton)
+KeplerEquation.approximateEccentricAnomaly(5.0, 0.100);      // 5.554599     (formula 22.4)
+```
+
+> **HOT TIP:** internally the chapter uses the *modified* eccentricity `e0 = e × 180/π` so the work
+> can be done in degrees. In Newton's correction the **numerator** carries `e0` while the
+> **denominator** carries the ordinary `e` — mixing them up is the easy transcription slip. Prefer
+> `solveEccentricAnomaly` (Newton) everywhere; the simple iteration can need 50+ steps near e = 1.
+
+---
+
+## 17. Constants — `Constants`
 
 | Constant | Value |
 |---|---|
@@ -491,7 +517,7 @@ ParallaxCorrection.parallaxFromDistanceInDegrees(0.3757);   // π from distance 
 
 ---
 
-## 17. BUILD & DEPENDENCIES
+## 18. BUILD & DEPENDENCIES
 
 ```
 mvn clean verify            # compile + run the 82-test suite + build the jar
@@ -504,7 +530,7 @@ mvn clean verify            # compile + run the 82-test suite + build the jar
 
 ---
 
-## 18. END-TO-END EXAMPLE
+## 19. END-TO-END EXAMPLE
 
 ```java
 // Where is Saturn in the sky from Uccle on 1978-11-13 at 04:34 UT?

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.nzv.astro</groupId>
 	<artifactId>meeus-engine</artifactId>
-	<version>1.6.0</version>
+	<version>1.7.0</version>
 	<packaging>jar</packaging>
 
 	<name>EphemerisEngine</name>

--- a/src/main/java/com/nzv/astro/ephemeris/KeplerEquation.java
+++ b/src/main/java/com/nzv/astro/ephemeris/KeplerEquation.java
@@ -1,0 +1,135 @@
+package com.nzv.astro.ephemeris;
+
+import static java.lang.Math.abs;
+import static java.lang.Math.atan2;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.lang.Math.toDegrees;
+import static java.lang.Math.toRadians;
+
+/**
+ * Solving the equation of Kepler, following chapter 22 of Jean Meeus'
+ * <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * The equation of Kepler is {@code E = M + e sin E} (formula 22.1), where
+ * {@code e} is the orbital eccentricity, {@code M} the mean anomaly and
+ * {@code E} the eccentric anomaly. It is transcendental and cannot be solved in
+ * closed form, so {@code E} is found iteratively. To allow the work to be done
+ * in degrees rather than radians, the chapter rewrites it as
+ * {@code E = M + e0 sin E} (formula 22.2) with the "modified" eccentricity
+ * {@code e0 = e * 180/pi}; all the methods below work in degrees.
+ * <p>
+ * Three methods are offered, matching the chapter:
+ * <ul>
+ * <li>{@link #solveEccentricAnomaly(double, double)} — Newton's correction
+ * (formula 22.3, the chapter's "second method"): converges quickly for every
+ * eccentricity and is the recommended general-purpose entry point;</li>
+ * <li>{@link #solveEccentricAnomalyByIteration(double, double, double)} — the
+ * simple fixed-point iteration (the chapter's "first method"): very simple, but
+ * slow to converge for large eccentricities;</li>
+ * <li>{@link #approximateEccentricAnomaly(double, double)} — the closed-form
+ * approximation (formula 22.4, the "third method"): valid only for small
+ * eccentricities.</li>
+ * </ul>
+ */
+public final class KeplerEquation {
+
+	private static final double DEFAULT_TOLERANCE_DEGREES = 1e-9d;
+	private static final int MAX_ITERATIONS = 200;
+
+	private KeplerEquation() {
+		// Utility class: no instances.
+	}
+
+	/**
+	 * Solves the equation of Kepler for the eccentric anomaly using Newton's
+	 * correction (formula 22.3), to a default accuracy of 1e-9 degree. This is
+	 * the recommended method: it converges quickly for every eccentricity in
+	 * [0, 1).
+	 *
+	 * @param meanAnomalyDegrees the mean anomaly M, in degrees.
+	 * @param eccentricity the orbital eccentricity e (0 ≤ e &lt; 1).
+	 * @return the eccentric anomaly E, in degrees.
+	 */
+	public static double solveEccentricAnomaly(double meanAnomalyDegrees, double eccentricity) {
+		return solveEccentricAnomaly(meanAnomalyDegrees, eccentricity, DEFAULT_TOLERANCE_DEGREES);
+	}
+
+	/**
+	 * Solves the equation of Kepler using Newton's correction (formula 22.3) to a
+	 * caller-specified accuracy. The fraction added at each step is a correction
+	 * to the previous value; iteration stops once its absolute value drops below
+	 * {@code toleranceDegrees}.
+	 *
+	 * @param meanAnomalyDegrees the mean anomaly M, in degrees.
+	 * @param eccentricity the orbital eccentricity e (0 ≤ e &lt; 1).
+	 * @param toleranceDegrees the convergence threshold on the correction, in
+	 *            degrees.
+	 * @return the eccentric anomaly E, in degrees.
+	 */
+	public static double solveEccentricAnomaly(double meanAnomalyDegrees, double eccentricity,
+			double toleranceDegrees) {
+		double modifiedEccentricity = toDegrees(eccentricity); // e0 = e * 180/pi
+		double E = meanAnomalyDegrees; // first approximation E0 = M
+		for (int i = 0; i < MAX_ITERATIONS; i++) {
+			double correction = (meanAnomalyDegrees + modifiedEccentricity * sin(toRadians(E)) - E)
+					/ (1 - eccentricity * cos(toRadians(E)));
+			E += correction;
+			if (abs(correction) < toleranceDegrees) {
+				break;
+			}
+		}
+		return E;
+	}
+
+	/**
+	 * Solves the equation of Kepler with the simple fixed-point iteration of the
+	 * chapter's first method: {@code E(n+1) = M + e0 sin E(n)}, starting from
+	 * {@code E0 = M}. Iteration stops once two successive values differ by less
+	 * than {@code toleranceDegrees}. This method is very simple but converges
+	 * slowly for large eccentricities, where {@link #solveEccentricAnomaly} is
+	 * preferable.
+	 *
+	 * @param meanAnomalyDegrees the mean anomaly M, in degrees.
+	 * @param eccentricity the orbital eccentricity e (0 ≤ e &lt; 1).
+	 * @param toleranceDegrees the convergence threshold between successive
+	 *            iterates, in degrees.
+	 * @return the eccentric anomaly E, in degrees.
+	 */
+	public static double solveEccentricAnomalyByIteration(double meanAnomalyDegrees,
+			double eccentricity, double toleranceDegrees) {
+		double modifiedEccentricity = toDegrees(eccentricity);
+		double E = meanAnomalyDegrees;
+		for (int i = 0; i < MAX_ITERATIONS; i++) {
+			double next = meanAnomalyDegrees + modifiedEccentricity * sin(toRadians(E));
+			double delta = next - E;
+			E = next;
+			if (abs(delta) < toleranceDegrees) {
+				break;
+			}
+		}
+		return E;
+	}
+
+	/**
+	 * Returns the closed-form approximation of the eccentric anomaly (formula
+	 * 22.4): {@code tan E = sin M / (cos M - e)}. This is valid only for small
+	 * eccentricities; the error grows quickly with e (about 0.16 degree at
+	 * e = 0.25, and far larger beyond that).
+	 *
+	 * @param meanAnomalyDegrees the mean anomaly M, in degrees.
+	 * @param eccentricity the orbital eccentricity e.
+	 * @return the approximate eccentric anomaly E, in degrees, in the range
+	 *         [0, 360).
+	 */
+	public static double approximateEccentricAnomaly(double meanAnomalyDegrees,
+			double eccentricity) {
+		double M = toRadians(meanAnomalyDegrees);
+		double E = toDegrees(atan2(sin(M), cos(M) - eccentricity));
+		double result = E % 360d;
+		if (result < 0) {
+			result += 360d;
+		}
+		return result;
+	}
+}

--- a/src/test/java/com/nzv/astro/ephemeris/impl/PhaseThreeStepThreeKeplerTest.java
+++ b/src/test/java/com/nzv/astro/ephemeris/impl/PhaseThreeStepThreeKeplerTest.java
@@ -1,0 +1,90 @@
+package com.nzv.astro.ephemeris.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.nzv.astro.ephemeris.KeplerEquation;
+
+/**
+ * Tests for Phase 3, step 3a of the implementation plan: chapter 22, the
+ * equation of Kepler.
+ * <p>
+ * Each of the chapter's three methods is anchored on its worked example (loose
+ * check against the book) with a pinned high-precision value (regression
+ * anchor), and the solver is checked for the obvious traps: e = 0 must return
+ * E = M, and a returned E must actually satisfy Kepler's equation.
+ */
+public class PhaseThreeStepThreeKeplerTest {
+
+	private static final double PIN = 1e-9;
+
+	// =====================================================================
+	// Chapter 22 - Equation of Kepler
+	// =====================================================================
+
+	@Test
+	public void testChapter22FirstMethodIteration() {
+		// Example 22.a: e = 0.100, M = 5 deg, fixed-point iteration to 1e-6 deg.
+		// Book: E = 5.554589.
+		double E = KeplerEquation.solveEccentricAnomalyByIteration(5.0d, 0.100d, 1e-6d);
+		Assert.assertEquals(5.554589d, E, 1e-6d);
+		Assert.assertEquals(5.554589200183587d, E, PIN);
+	}
+
+	@Test
+	public void testChapter22SecondMethodNewton() {
+		// Example 22.b: same data via Newton's correction (formula 22.3).
+		// Book: E = 5.554589253 after only three iterations.
+		double E = KeplerEquation.solveEccentricAnomaly(5.0d, 0.100d);
+		Assert.assertEquals(5.554589253d, E, 1e-9d);
+		Assert.assertEquals(5.554589253872315d, E, PIN);
+	}
+
+	@Test
+	public void testChapter22NewtonHandlesHighEccentricity() {
+		// The chapter's hard case: e = 0.990, M = 2 deg. The fixed-point iteration
+		// is still wrong after 50 steps, but Newton converges. Book correct value:
+		// E = 32.361007.
+		double E = KeplerEquation.solveEccentricAnomaly(2.0d, 0.990d);
+		Assert.assertEquals(32.361007d, E, 1e-6d);
+		Assert.assertEquals(32.36100747203112d, E, PIN);
+	}
+
+	@Test
+	public void testChapter22ApproximateThirdMethod() {
+		// Formula 22.4 (closed-form approximation), valid for small e.
+		// Example data e = 0.100, M = 5 deg: book E = 5.554599 (exact 5.554589).
+		double E = KeplerEquation.approximateEccentricAnomaly(5.0d, 0.100d);
+		Assert.assertEquals(5.554599d, E, 1e-6d);
+		Assert.assertEquals(5.554598871530979d, E, PIN);
+		// The approximation's error here is well under a thousandth of a degree.
+		double exact = KeplerEquation.solveEccentricAnomaly(5.0d, 0.100d);
+		Assert.assertTrue(Math.abs(E - exact) < 1e-4d);
+	}
+
+	@Test
+	public void testChapter22ZeroEccentricityReturnsMeanAnomaly() {
+		// With a circular orbit the eccentric anomaly equals the mean anomaly.
+		for (double M : new double[] { 0.0d, 5.0d, 123.0d, 280.0d }) {
+			Assert.assertEquals(M, KeplerEquation.solveEccentricAnomaly(M, 0.0d), PIN);
+			Assert.assertEquals(M, KeplerEquation.solveEccentricAnomalyByIteration(M, 0.0d, 1e-9d),
+					PIN);
+		}
+	}
+
+	@Test
+	public void testChapter22SolutionSatisfiesKeplersEquation() {
+		// A returned E must satisfy E = M + e0 sin E (formula 22.2) across a range
+		// of eccentricities and mean anomalies.
+		double[] eccentricities = { 0.0d, 0.0167d, 0.25d, 0.5d, 0.9d, 0.99d };
+		double[] meanAnomalies = { 2.0d, 47.0d, 130.0d, 200.0d, 310.0d };
+		for (double e : eccentricities) {
+			double e0 = Math.toDegrees(e);
+			for (double M : meanAnomalies) {
+				double E = KeplerEquation.solveEccentricAnomaly(M, e);
+				double residual = E - e0 * Math.sin(Math.toRadians(E)) - M;
+				Assert.assertEquals("Kepler residual for e=" + e + " M=" + M, 0.0d, residual, 1e-7d);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds KeplerEquation, a self-contained solver for E = M + e sin E, with all three methods of the chapter:

- solveEccentricAnomaly(M, e[, tol])         Newton's correction (22.3, recommended)
- solveEccentricAnomalyByIteration(M, e, tol)  fixed-point iteration (first method)
- approximateEccentricAnomaly(M, e)           closed-form approximation (22.4)

All in degrees, using the modified eccentricity e0 = e*180/pi; no external solver. Validated on Examples 22.a (E=5.554589) and 22.b (E=5.554589253), the hard case e=0.99/M=2 (E=32.361007), e=0 -> E=M, and a Kepler-residual guard across (e, M).

Binary Stars (Ch 38) deferred to a later release. Suite 102 -> 108 tests. Version 1.6.0 -> 1.7.0.