### PR TITLE
Phase 4 (step 1): Chapter 25 — Elliptic-motion engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 1.8.0 — Phase 4 (step 1): Elliptic-motion engine (Chapter 25)
+
+This release adds the **elliptic-motion engine** (Chapter 25), the keystone that turns orbital
+elements into a geocentric position. It is algorithm-bound and table-free: it consumes
+caller-supplied `OrbitalElements`, so it ships independently of the Chapter 23/24 planetary-data
+track. Both of the chapter's methods are implemented. The suite grows from 108 to 121 tests, all
+passing.
+
+### New features
+
+- **Chapter 25 — Elliptic Motion.** New package `com.nzv.astro.ephemeris.orbit` with a static
+  `EllipticMotion` utility, an `OrbitalElements` record and an `OrbitPosition` result.
+  - **First method** (major planets, elements of the mean equinox of date): `heliocentricEcliptic`
+    (25.1–25.6), `geocentricEcliptic` (25.7–25.9) and `firstMethod(...)`, with a `julianDay`
+    overload that takes the Sun's geometric longitude, radius vector and the obliquity of the date
+    from the engine itself.
+  - **Second method** (minor planets and comets, standard-equinox elements): `gaussianConstants`
+    (25.13), `heliocentricEquatorialRectangular` (25.14) and `secondMethod(...)` (25.15), reusing
+    `sunRectangularEquatorialCoordinates(jd, equinox)` (Chapter 19) directly. A
+    `secondMethodLightTimeCorrected(...)` overload applies the light-time correction (25.10),
+    iterating the body to `t − τ` while the Sun stays at `t`.
+  - Elongation and phase angle (page 120) on every result, plus the comet (25.16) and minor-planet
+    magnitude helpers.
+- **`OrbitalElements`** record: classical elements `a, e, i, ω, Ω` plus a mean anomaly at an epoch
+  and a daily mean motion, with `meanAnomalyAt(jd)` and factories `fromMeanAnomalyAtEpoch`,
+  `fromPerihelionPassage`, and the derivations `meanMotionFromSemiMajorAxis` (25.12) and
+  `semiMajorAxisFromPerihelionDistance`.
+
+### Scope
+
+The positions returned are the body's **geometric** coordinates, exactly as the chapter's worked
+examples produce them, plus the well-defined light-time/astrometric correction. Nutation and
+aberration (the remaining corrections to a fully *apparent* place, Chapter 16) are deliberately left
+to the caller: the book itself stops at the geometric position and defers those, and the correct
+combination of light-time and stellar aberration for a solar-system body is a separate concern best
+handled as its own step.
+
+### Validation
+
+- **Example 25.a** (Mercury, first method): heliocentric `l, b, r`, geocentric `λ, β, Δ` and the
+  equatorial `α, δ` of date all reproduce the book to its printed precision; the `julianDay`
+  overload reproduces it through the library's own Sun to ~1e-4°.
+- **Example 25.b** (433 Eros, second method): the Gaussian constants, `x, y, z`, `Δ`, `α₁₉₅₀`,
+  `δ₁₉₅₀`, elongation, phase angle and magnitude all reproduce the book against its printed Sun
+  `X, Y, Z`. Through the library's Chapter-19 Sun the agreement is ~0.04° — the near-Earth geometry
+  (Δ = 0.175 AU) amplifies the known ~1e-4 AU equinox-reduction residual — and the value is pinned.
+- **Minor planet 234 Barbara** (the chapter's exercise): the `julianDay` + light-time path matches
+  the published *Ephemerides of Minor Planets for 1979* to ≤0.012° across the tabulated dates.
+
 ## 1.7.0 — Phase 3 (step 3a): Equation of Kepler
 
 This release adds **Chapter 22** (the equation of Kepler), the small transcendental solver that

--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -42,6 +42,16 @@
 > the new `KeplerEquation` utility solves `E = M + e sin E` with all three methods of the chapter
 > (Newton's correction, the simple fixed-point iteration, and the closed-form approximation),
 > validated on Examples 22.a/22.b and the high-eccentricity case. Binary Stars (38) follows later.
+>
+> **Version note (1.8.0):** Phase 4, step 1 (the orbital-motion keystone) is complete.
+> **25 Elliptic Motion** moves 0% → 95%: the new `com.nzv.astro.ephemeris.orbit` package implements
+> both methods of the chapter — the first (major planets, mean equinox of date) and the second
+> (minor planets/comets, standard-equinox elements, reusing the Chapter-19 Sun) — driven by a
+> caller-supplied `OrbitalElements`. Validated on Examples 25.a (Mercury) and 25.b (433 Eros) and on
+> the chapter's published-ephemeris exercise (234 Barbara). The positions are geometric, with the
+> light-time correction available; nutation/aberration onto a fully apparent place (Chapter 16) are
+> left to the caller, hence 95% rather than 100%. No table data is involved — this is the engine the
+> data-bound planetary track (Chapters 23/24) will feed later.
 
 > **Version note (1.3.0):** Phase 2, step 1 (the star keystone) is complete.
 > **16 Apparent Place of a Star** moves 25% → 95%: proper motion, precession, nutation
@@ -106,7 +116,7 @@ utilities beyond the reference edition.
 | 22 | Equation of Kepler | MEDIUM | `██████████` 100% |
 | 23 | Elements of the Planetary Orbits | MEDIUM | `░░░░░░░░░░` 0% |
 | 24 | Planets: Principal Perturbations | HIGH | `░░░░░░░░░░` 0% |
-| 25 | Elliptic Motion | HIGH | `░░░░░░░░░░` 0% |
+| 25 | Elliptic Motion | HIGH | `█████████░` 95% |
 | 26 | Parabolic Motion | MEDIUM | `░░░░░░░░░░` 0% |
 | 27 | Planets in Perihelion and Aphelion | MEDIUM | `░░░░░░░░░░` 0% |
 | 28 | Passages Through the Nodes | MEDIUM | `░░░░░░░░░░` 0% |
@@ -254,10 +264,10 @@ chapters of the 39-chapter edition, so excluded from the per-chapter percentages
 **Applications.** Bringing planetary positions to arc-minute (and better) accuracy.
 **Coverage.** Not implemented.
 
-### 25 — Elliptic Motion · Complexity: HIGH · `░░░░░░░░░░` 0%
-**Formulae.** From elements → heliocentric → geocentric equatorial coordinates of a body in an elliptical orbit.
-**Applications.** Positions of planets and elliptical-orbit minor planets.
-**Coverage.** Not implemented.
+### 25 — Elliptic Motion · Complexity: HIGH · `█████████░` 95%
+**Formulae.** From elements → heliocentric → geocentric equatorial coordinates of a body in an elliptical orbit (both methods: 25.1–25.16).
+**Applications.** Positions of planets and elliptical-orbit minor planets and comets.
+**Coverage.** Implemented in `com.nzv.astro.ephemeris.orbit` (`EllipticMotion`, `OrbitalElements`, `OrbitPosition`). First method (major planets, mean equinox of date) and second method (minor planets/comets, standard-equinox elements, reusing the Chapter-19 Sun and the Chapter-22 Kepler solver), driven by caller-supplied elements. Geometric positions plus elongation, phase angle, light-time correction (25.10) and the magnitude relations (25.16). Validated on Examples 25.a (Mercury) and 25.b (433 Eros) and the 234 Barbara published-ephemeris exercise. The remaining 5% is nutation/aberration onto a fully apparent place (Chapter 16), deliberately left to the caller.
 
 ### 26 — Parabolic Motion · Complexity: MEDIUM · `░░░░░░░░░░` 0%
 **Formulae.** Position of a body on a parabolic orbit (Barker's equation).

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -11,7 +11,8 @@
 | **1 — Enablers & quick wins** | ✅ **DONE (v1.2.0)** | 6, 9, 14, 18, 38, 42 | All shipped with regression tests; 43 → 63 tests. |
 | **2 — The two keystones** | ✅ **Done (v1.4.0)** | 16 ✅, 30 ✅ | Star keystone (16) and Moon keystone (30, table-driven series) both shipped. |
 | **3 — Harvest** | 🟦 In progress — steps 1–2 ✅, 3a ✅ (v1.5.0–v1.7.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 22 ✅, 29 ✅, 31 ✅, 32 ✅ · then 38 | Steps 1–2 and 3a (equation of Kepler) shipped, 82 → 108 tests. Step 3b (binary stars, Ch 38) is the last Harvest item. |
-| *Deferred* | ⬜ Out of scope | 23–28, 34–36, 43 | Planetary suite. |
+| **4 — Orbital-motion engine & minor bodies** | 🟦 In progress — step 1 ✅ (v1.8.0) | 25 ✅ · then 26, 27, 28, 36 | Elliptic-motion engine (Ch 25) shipped, 108 → 121 tests. Algorithm-bound, table-free; runs in parallel with the Ch 23/24 data-acquisition track. |
+| *Deferred* | ⬜ Out of scope (data-bound) | 23–24, 34–35, 43 | Major-planet data (elements + perturbations) and Phase-5 derived phenomena. |
 
 **What changed in v1.2.0 (Phase 1):**
 - **Ch 18 Solar Coordinates** 25% → **100%** — equation of centre, true/apparent longitude, radius vector, mean obliquity, apparent RA/Dec.
@@ -81,11 +82,24 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 - ✅ **Step 1 — Moon phenomena + Sun bonuses (DONE, v1.5.0).** Ch 31 (illuminated fraction), Ch 13 (bright-limb position angle), Ch 32 (phases), plus the Sun-adjacent bonuses Ch 20 (equinoxes & solstices) and Ch 19 (rectangular coordinates of the Sun, of-date and reduced to a chosen equinox). All five validated on their Meeus worked examples; suite 82 → 94 tests.
 - ✅ **Step 2 — Parallax + Equation of Time (DONE, v1.6.0).** Ch 29 (topocentric parallax — rigorous and non-rigorous reduction plus a Moon convenience, using Ch 6 ✅) and the Sun bonus Ch 21 (Equation of Time). The Moon rise/transit/set refinement once planned here is **dropped**: re-anchoring to the working 39-chapter edition showed it has no Rising/Transit/Setting chapter, so there is no text to transcribe or worked example to validate against; the first-approximation calculator stays as a supplementary utility. This step also **re-anchored the project's chapter numbering** to the working edition (Stellar Magnitudes 38→37, Binary Stars 39→38, Linear Regression 40→39; the phantom Central Meridian of Jupiter removed; Refraction/RTS reclassified as supplementary, Pluto dropped).
 - ✅ **Step 3a — Equation of Kepler (DONE, v1.7.0).** Ch 22 (Equation of Kepler) implemented as the `KeplerEquation` utility with all three methods of the chapter (Newton's correction, fixed-point iteration, closed-form approximation), hand-iterated with no external solver. Validated on Examples 22.a/22.b and the high-eccentricity case.
-- ⬜ **Step 3b — Binary stars (v1.8.0).** Ch 38 (binary stars), whose apparent-orbit solution reuses the Kepler solver just shipped and whose separation/position-angle output reuses Ch 9 ✅. The last Harvest item.
+- ⬜ **Step 3b — Binary stars (a later release).** Ch 38 (binary stars), whose apparent-orbit solution reuses the Kepler solver just shipped and whose separation/position-angle output reuses Ch 9 ✅. The last Harvest item; independent of the Phase 4 engine track now under way in parallel.
 
 **Note on the true-vs-apparent longitude split:** within step 1, the elongation chapters (31, 13) use the Sun's *true* longitude, while equinoxes/solstices (20) use the *apparent* longitude — the apparent place is what defines the season. Mixing these up is a silent error, so it is called out in the findings log.
 
 **Deliberately deferred:** the planetary suite (Ch 23–28, 34–36, 43), shown as the `23+` cluster in the matrix's bottom-right. It's the largest body of work in the book and the least aligned with a Moon/star focus, so it sits in the "defer" quadrant until those tracks are complete.
+
+---
+
+## Phase 4 — Orbital-motion engine & minor bodies 🟦 IN PROGRESS
+*Algorithm-bound, table-free. Consumes caller-supplied elements, so it ships independently of the Ch 23/24 planetary-data track and runs in parallel with it (per the Planets & Minor Bodies proposal, Option C).*
+
+The keystone here is **Chapter 25 (Elliptic Motion)**: it turns orbital elements into a geocentric position and is reused by every later planet and minor-body chapter. It needs no perturbation tables — only the Chapter-22 Kepler solver ✅ and the Chapter-19 Sun ✅, both already in the library.
+
+- ✅ **Step 1 — Elliptic-motion engine (DONE, v1.8.0).** Ch 25, both methods, in the new `com.nzv.astro.ephemeris.orbit` package (`EllipticMotion`, `OrbitalElements`, `OrbitPosition`). The first method (major planets, mean equinox of date) forms heliocentric → geocentric ecliptic → equatorial of date; the second method (minor planets/comets, standard-equinox elements) forms heliocentric rectangular equatorial coordinates via the per-orbit Gaussian constants and reads RA/Dec directly off the Chapter-19 Sun, with a light-time correction. Geometric positions plus elongation, phase angle and the magnitude relations. Validated on Examples 25.a (Mercury) and 25.b (433 Eros) and the 234 Barbara published-ephemeris exercise; suite 108 → 121 tests.
+- ⬜ **Step 2 — Parabolic motion / comets (Ch 26).** Barker's equation (direct cubic, no iteration) feeding the same geocentric reduction. Self-contained, no tables; the best value-per-effort item left.
+- ⬜ **Step 3 — Light derived chapters (Ch 27, 28, 36).** Perihelion/aphelion instants, nodal passages and semidiameter, for caller-supplied elements/distances.
+
+**End-of-phase deliverable:** *"give me the apparent position of any comet or minor planet from its orbital elements,"* plus apsides, nodes and semidiameter — entirely algorithm-bound. The data-bound major-planet work (Ch 23 elements, Ch 24 perturbations on a `planetary` table package, Ch 34, Ch 10 capstone) is **Phase 5**, gated on the data-acquisition track now running in parallel.
 
 ---
 
@@ -104,4 +118,5 @@ Each of these was "high effort" only because it presupposed a Moon or Sun positi
 | **1** | Enablers & quick wins | 6, 9, 14, 18, 38, 42 | Low–medium | ✅ Done (v1.2.0) | The substrate for both keystones |
 | **2** | The two keystones | 16 ✅, 30 ✅ | High | ✅ Done (v1.4.0) | Both priority tracks' hard core |
 | **3** | Harvest | 13 ✅ 19 ✅ 20 ✅ 21 ✅ 22 ✅ 29 ✅ 31 ✅ 32 ✅ · then 38 | Low (post-keystone) | 🟦 Steps 1–2, 3a done (v1.5.0–v1.7.0) | The derived Moon and star phenomena |
-| *Deferred* | Planetary suite | 23–28, 34–36, 43 | High | ⬜ | (Out of scope for a Moon/star focus) |
+| **4** | Orbital-motion engine & minor bodies | 25 ✅ · then 26, 27, 28, 36 | Medium (algorithm-bound) | 🟦 Step 1 done (v1.8.0) | Positions of comets & minor planets from elements |
+| *Phase 5* | Major planets (data-bound) | 23, 24, 34, 10 | High | ⬜ | Built-in major-planet positions; gated on data acquisition |

--- a/REFCARD.md
+++ b/REFCARD.md
@@ -2,7 +2,7 @@
 
 ### The astronomical formulae of Jean Meeus, in Java
 
-> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Equation of Kepler &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
+> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Equation of Kepler &nbsp;·&nbsp; Elliptic Motion &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
 
 ---
 
@@ -504,7 +504,60 @@ KeplerEquation.approximateEccentricAnomaly(5.0, 0.100);      // 5.554599     (fo
 
 ---
 
-## 17. Constants — `Constants`
+## 17. Elliptic Motion — `EllipticMotion` / `OrbitalElements` / `OrbitPosition` (static, Ch. 25)
+
+`com.nzv.astro.ephemeris.orbit`. Geocentric position of a planet, minor planet or comet from its
+orbital elements. Two methods, both pure statics. Angles in **degrees**, distances in **AU**. Each
+call returns an `OrbitPosition` (`equatorial` RA/Dec in degrees, `radiusVectorAU` *r*,
+`distanceToEarthAU` Δ, `elongationDegrees` ψ, `phaseAngleDegrees`).
+
+**First method** — major planets, elements of the **mean equinox of date** (`L, a, e, i, Ω, M`):
+
+| Method | Returns |
+|---|---|
+| `heliocentricEcliptic(L, a, e, i, Ω, M)` | `{l, b, r}` (25.1–25.6) |
+| `geocentricEcliptic(l, b, r, Θ, R)` | `{λ, β, Δ}` (25.7–25.9) |
+| `firstMethod(L, a, e, i, Ω, M, Θ, R, ε)` | `OrbitPosition` of date |
+| `firstMethod(engine, jd, L, a, e, i, Ω, M)` | as above, with Θ/R/ε from the engine |
+
+**Second method** — minor planets & comets, **standard-equinox** elements (`OrbitalElements`):
+
+| Method | Returns |
+|---|---|
+| `gaussianConstants(Ω, i, ε)` | `{a, b, c, A, B, C}` (25.13), constant for the orbit |
+| `heliocentricEquatorialRectangular(el, M, ε)` | `{x, y, z, r}` (25.14) |
+| `secondMethod(el, M, X, Y, Z, ε)` | `OrbitPosition` (25.15), Sun X/Y/Z same equinox |
+| `secondMethod(engine, jd, el, equinox, ε)` | as above, Sun from Ch. 19 |
+| `secondMethodLightTimeCorrected(engine, jd, el, equinox, ε)` | astrometric place, light-time (25.10) |
+
+`OrbitalElements` — `a, e, i, ω, Ω` plus a mean anomaly at an epoch and daily mean motion *n*;
+`meanAnomalyAt(jd)`; factories `fromMeanAnomalyAtEpoch(...)`, `fromPerihelionPassage(...)`;
+helpers `meanMotionFromSemiMajorAxis(a)` (25.12), `semiMajorAxisFromPerihelionDistance(q, e)`.
+
+```java
+EphemerisEngine engine = new EphemerisEngineImpl();
+
+// First method — Mercury, 1978 Nov 12.0 ET (book Example 25.a):
+OrbitPosition mercury = EllipticMotion.firstMethod(engine, 2443824.5,
+        337.053200, 0.3870986, 0.20563033, 7.004337, 48.080736, 259.92660);
+// α ≈ 249.3176°, δ ≈ −24.7477° (of date)
+
+// Second method — 433 Eros, 1975 Feb 11.0 ET (book Example 25.b):
+OrbitalElements eros = OrbitalElements.fromPerihelionPassage(
+        1.4579641, 0.2227021, 10.82772, 178.44991, 303.83085, 2442437.20450, 0.55986565);
+OrbitPosition p = EllipticMotion.secondMethodLightTimeCorrected(
+        engine, 2442454.5, eros, 1950.0, 23.4457889);   // α/δ referred to 1950.0
+```
+
+> **HOT TIP:** keep the elements and the Sun on the **same equinox** — the one hard rule of the
+> second method. Pass the matching obliquity (`23.4457889°` for 1950.0). The positions are
+> **geometric** (as the book's examples are); apply nutation & aberration (Ch. 16) yourself for a
+> fully apparent place. Don't reuse `EclipticCoordinatesAdapter` for the of-date conversion — it is
+> hard-wired to the 1950.0 obliquity; the engine converts with the obliquity *of date*.
+
+---
+
+## 18. Constants — `Constants`
 
 | Constant | Value |
 |---|---|
@@ -517,7 +570,7 @@ KeplerEquation.approximateEccentricAnomaly(5.0, 0.100);      // 5.554599     (fo
 
 ---
 
-## 18. BUILD & DEPENDENCIES
+## 19. BUILD & DEPENDENCIES
 
 ```
 mvn clean verify            # compile + run the 82-test suite + build the jar
@@ -530,7 +583,7 @@ mvn clean verify            # compile + run the 82-test suite + build the jar
 
 ---
 
-## 19. END-TO-END EXAMPLE
+## 20. END-TO-END EXAMPLE
 
 ```java
 // Where is Saturn in the sky from Uccle on 1978-11-13 at 04:34 UT?

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.nzv.astro</groupId>
 	<artifactId>meeus-engine</artifactId>
-	<version>1.7.0</version>
+	<version>1.8.0</version>
 	<packaging>jar</packaging>
 
 	<name>EphemerisEngine</name>

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/EllipticMotion.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/EllipticMotion.java
@@ -1,0 +1,419 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static java.lang.Math.asin;
+import static java.lang.Math.acos;
+import static java.lang.Math.atan2;
+import static java.lang.Math.cos;
+import static java.lang.Math.hypot;
+import static java.lang.Math.log10;
+import static java.lang.Math.sin;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.tan;
+import static java.lang.Math.toDegrees;
+import static java.lang.Math.toRadians;
+
+import com.nzv.astro.ephemeris.EphemerisEngine;
+import com.nzv.astro.ephemeris.KeplerEquation;
+import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
+
+/**
+ * Geocentric ephemeris of a body in elliptic orbit, following chapter 25 of Jean
+ * Meeus' <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * The chapter gives two methods, both implemented here as pure, stateless static
+ * helpers:
+ * <ul>
+ * <li>The <b>first method</b> ({@link #firstMethod}) is suited to the major
+ * planets. It works from elements referred to the mean equinox <i>of the
+ * date</i>: it forms the body's heliocentric ecliptical longitude, latitude and
+ * radius vector ({@link #heliocentricEcliptic}), combines them with the Sun's
+ * geometric longitude and radius vector to obtain the geocentric ecliptical
+ * coordinates ({@link #geocentricEcliptic}), and converts those to right
+ * ascension and declination of the date.</li>
+ * <li>The <b>second method</b> ({@link #secondMethod}) is suited to minor
+ * planets and periodic comets. It works from elements referred to a standard
+ * equinox: it forms the body's heliocentric rectangular <i>equatorial</i>
+ * coordinates from the per-orbit Gaussian constants ({@link #gaussianConstants}),
+ * adds the Sun's geocentric rectangular equatorial coordinates referred to the
+ * same equinox, and reads the right ascension and declination directly.</li>
+ * </ul>
+ * <p>
+ * The positions returned are the body's <i>geometric</i> coordinates, exactly as
+ * the chapter's worked examples 25.a and 25.b produce them. The effect of
+ * light-time can be applied with {@link #secondMethodLightTimeCorrected} (which
+ * places the body at the retarded instant {@code t - tau} while keeping the Sun
+ * at {@code t}); nutation and aberration — the remaining corrections to a fully
+ * apparent place, see chapter 16 — are left to the caller.
+ * <p>
+ * All angles are in degrees throughout, distances in astronomical units.
+ */
+public final class EllipticMotion {
+
+	/**
+	 * The light-time constant of formula (25.10): {@code tau = 0.0057756 * Delta}
+	 * days.
+	 */
+	public static final double LIGHT_TIME_CONSTANT = 0.0057756d;
+
+	private EllipticMotion() {
+		// Utility class: no instances.
+	}
+
+	/* --------------------------------------------------------------------- */
+	/* Shared orbital-plane quantities (true anomaly and radius vector).      */
+	/* --------------------------------------------------------------------- */
+
+	/**
+	 * Solves the orbit in its plane: from the mean anomaly and the elements,
+	 * returns the true anomaly {@code v} (degrees, in [0, 360)) and the radius
+	 * vector {@code r} (AU). Uses the equation of Kepler (chapter 22), then
+	 * formulae (25.1) and (25.2).
+	 *
+	 * @param meanAnomalyDegrees the mean anomaly {@code M}, in degrees.
+	 * @param eccentricity the eccentricity {@code e}.
+	 * @param semiMajorAxisAU the semimajor axis {@code a}, in AU.
+	 * @return {@code {v, r}} — true anomaly in degrees and radius vector in AU.
+	 */
+	public static double[] trueAnomalyAndRadius(double meanAnomalyDegrees,
+			double eccentricity, double semiMajorAxisAU) {
+		double E = KeplerEquation.solveEccentricAnomaly(meanAnomalyDegrees, eccentricity);
+		double halfE = toRadians(E / 2d);
+		double v = normalize(2d * toDegrees(atan2(
+				sqrt(1d + eccentricity) * sin(halfE),
+				sqrt(1d - eccentricity) * cos(halfE))));        // (25.1)
+		double r = semiMajorAxisAU * (1d - eccentricity * cos(toRadians(E))); // (25.2)
+		return new double[] { v, r };
+	}
+
+	/* --------------------------------------------------------------------- */
+	/* First method (major planets, elements of the mean equinox of date).    */
+	/* --------------------------------------------------------------------- */
+
+	/**
+	 * Heliocentric ecliptical coordinates of the planet (first method), formulae
+	 * (25.1)&ndash;(25.6).
+	 *
+	 * @param meanLongitudeDegrees the mean longitude {@code L}, in degrees.
+	 * @param semiMajorAxisAU the semimajor axis {@code a}, in AU.
+	 * @param eccentricity the eccentricity {@code e}.
+	 * @param inclinationDegrees the inclination {@code i}, in degrees.
+	 * @param nodeLongitudeDegrees the longitude of the ascending node
+	 *            {@code Omega}, in degrees.
+	 * @param meanAnomalyDegrees the mean anomaly {@code M}, in degrees.
+	 * @return {@code {l, b, r}} — heliocentric longitude (deg, [0, 360)),
+	 *         latitude (deg) and radius vector (AU).
+	 */
+	public static double[] heliocentricEcliptic(double meanLongitudeDegrees,
+			double semiMajorAxisAU, double eccentricity, double inclinationDegrees,
+			double nodeLongitudeDegrees, double meanAnomalyDegrees) {
+		double[] vr = trueAnomalyAndRadius(meanAnomalyDegrees, eccentricity, semiMajorAxisAU);
+		double v = vr[0];
+		double r = vr[1];
+		double u = meanLongitudeDegrees + v - meanAnomalyDegrees - nodeLongitudeDegrees; // (25.3)
+		double uRad = toRadians(u);
+		double lMinusNode = toDegrees(atan2(
+				cos(toRadians(inclinationDegrees)) * sin(uRad), cos(uRad)));     // (25.5)
+		double l = normalize(nodeLongitudeDegrees + lMinusNode);                 // (25.4)
+		double b = toDegrees(asin(sin(uRad) * sin(toRadians(inclinationDegrees)))); // (25.6)
+		return new double[] { l, b, r };
+	}
+
+	/**
+	 * Geocentric ecliptical coordinates from the heliocentric ones and the Sun
+	 * (first method), formulae (25.7)&ndash;(25.9).
+	 *
+	 * @param l heliocentric longitude {@code l}, in degrees.
+	 * @param b heliocentric latitude {@code b}, in degrees.
+	 * @param r heliocentric radius vector {@code r}, in AU.
+	 * @param sunGeometricLongitudeDegrees the Sun's geometric longitude
+	 *            {@code Theta} (chapter 18), in degrees.
+	 * @param sunRadiusVectorAU the Sun's radius vector {@code R} (chapter 18), in
+	 *            AU.
+	 * @return {@code {lambda, beta, Delta}} — geocentric longitude (deg,
+	 *         [0, 360)), latitude (deg) and Earth distance (AU).
+	 */
+	public static double[] geocentricEcliptic(double l, double b, double r,
+			double sunGeometricLongitudeDegrees, double sunRadiusVectorAU) {
+		double cosB = cos(toRadians(b));
+		double lMinusTheta = toRadians(l - sunGeometricLongitudeDegrees);
+		double N = r * cosB * sin(lMinusTheta);
+		double D = r * cosB * cos(lMinusTheta) + sunRadiusVectorAU;               // (25.7)
+		double lambda = normalize(sunGeometricLongitudeDegrees + toDegrees(atan2(N, D)));
+		double rSinB = r * sin(toRadians(b));
+		double delta = sqrt(N * N + D * D + rSinB * rSinB);                        // (25.8)
+		double beta = toDegrees(asin(rSinB / delta));                             // (25.9)
+		return new double[] { lambda, beta, delta };
+	}
+
+	/**
+	 * Full geocentric position by the first method, from elements of the mean
+	 * equinox of the date and the Sun's geometric longitude, radius vector and
+	 * the obliquity of the date. The right ascension and declination are referred
+	 * to the mean equinox of the date.
+	 */
+	public static OrbitPosition firstMethod(double meanLongitudeDegrees, double semiMajorAxisAU,
+			double eccentricity, double inclinationDegrees, double nodeLongitudeDegrees,
+			double meanAnomalyDegrees, double sunGeometricLongitudeDegrees,
+			double sunRadiusVectorAU, double obliquityDegrees) {
+		double[] lbr = heliocentricEcliptic(meanLongitudeDegrees, semiMajorAxisAU, eccentricity,
+				inclinationDegrees, nodeLongitudeDegrees, meanAnomalyDegrees);
+		double[] geo = geocentricEcliptic(lbr[0], lbr[1], lbr[2],
+				sunGeometricLongitudeDegrees, sunRadiusVectorAU);
+		double lambda = geo[0];
+		double beta = geo[1];
+		double delta = geo[2];
+		double r = lbr[2];
+		EquatorialCoordinates eq = eclipticToEquatorial(lambda, beta, obliquityDegrees);
+		double elongation = elongation(r, delta, sunRadiusVectorAU);
+		double phase = phaseAngle(r, delta, sunRadiusVectorAU);
+		return new OrbitPosition(eq, r, delta, elongation, phase);
+	}
+
+	/**
+	 * Convenience overload of the first method that takes the Sun's geometric
+	 * longitude, radius vector and the obliquity of the date from the engine
+	 * itself, for the given instant. Produces the geometric position referred to
+	 * the mean equinox of the date.
+	 *
+	 * @param engine the ephemeris engine providing the Sun (chapter 18).
+	 * @param julianDay the instant, as a Julian Day (Ephemeris Time).
+	 */
+	public static OrbitPosition firstMethod(EphemerisEngine engine, double julianDay,
+			double meanLongitudeDegrees, double semiMajorAxisAU, double eccentricity,
+			double inclinationDegrees, double nodeLongitudeDegrees, double meanAnomalyDegrees) {
+		double T = engine.T(julianDay);
+		double theta = engine.sunTrueLongitude(T);   // the Sun's geometric longitude
+		double R = engine.sunRadiusVector(T);
+		double obliquity = engine.meanObliquityOfEcliptic(T);
+		return firstMethod(meanLongitudeDegrees, semiMajorAxisAU, eccentricity, inclinationDegrees,
+				nodeLongitudeDegrees, meanAnomalyDegrees, theta, R, obliquity);
+	}
+
+	/* --------------------------------------------------------------------- */
+	/* Second method (minor planets and comets, standard-equinox elements).   */
+	/* --------------------------------------------------------------------- */
+
+	/**
+	 * The per-orbit Gaussian constants of formula (25.13). They depend only on
+	 * the node, the inclination and the obliquity, hence are constant for a whole
+	 * ephemeris. The returned magnitudes {@code a, b, c} are taken positive and
+	 * the angles {@code A, B, C} (degrees) are placed in the correct quadrant.
+	 *
+	 * @param nodeLongitudeDegrees the longitude of the ascending node
+	 *            {@code Omega}, in degrees.
+	 * @param inclinationDegrees the inclination {@code i}, in degrees.
+	 * @param obliquityDegrees the obliquity {@code epsilon} of the elements'
+	 *            equinox, in degrees.
+	 * @return {@code {a, b, c, A, B, C}} — three magnitudes then three angles
+	 *         (degrees).
+	 */
+	public static double[] gaussianConstants(double nodeLongitudeDegrees,
+			double inclinationDegrees, double obliquityDegrees) {
+		double node = toRadians(nodeLongitudeDegrees);
+		double i = toRadians(inclinationDegrees);
+		double eps = toRadians(obliquityDegrees);
+		double F = cos(node);
+		double G = sin(node) * cos(eps);
+		double H = sin(node) * sin(eps);
+		double P = -sin(node) * cos(i);
+		double Q = cos(node) * cos(i) * cos(eps) - sin(i) * sin(eps);
+		double R = cos(node) * cos(i) * sin(eps) + sin(i) * cos(eps);
+		double A = toDegrees(atan2(F, P));
+		double B = toDegrees(atan2(G, Q));
+		double C = toDegrees(atan2(H, R));
+		return new double[] { hypot(F, P), hypot(G, Q), hypot(H, R), A, B, C };
+	}
+
+	/**
+	 * Heliocentric rectangular equatorial coordinates of the body (second
+	 * method), formula (25.14), referred to the elements' standard equinox.
+	 *
+	 * @param elements the orbital elements.
+	 * @param meanAnomalyDegrees the mean anomaly {@code M} for the instant, in
+	 *            degrees.
+	 * @param obliquityDegrees the obliquity of the elements' equinox, in degrees.
+	 * @return {@code {x, y, z}} in AU, plus {@code r} (AU) as a fourth element.
+	 */
+	public static double[] heliocentricEquatorialRectangular(OrbitalElements elements,
+			double meanAnomalyDegrees, double obliquityDegrees) {
+		double[] g = gaussianConstants(elements.ascendingNodeLongitudeDegrees(),
+				elements.inclinationDegrees(), obliquityDegrees);
+		double[] vr = trueAnomalyAndRadius(meanAnomalyDegrees, elements.eccentricity(),
+				elements.semiMajorAxisAU());
+		double v = vr[0];
+		double r = vr[1];
+		double omega = elements.argumentOfPerihelionDegrees();
+		double x = r * g[0] * sin(toRadians(g[3] + omega + v));
+		double y = r * g[1] * sin(toRadians(g[4] + omega + v));
+		double z = r * g[2] * sin(toRadians(g[5] + omega + v));
+		return new double[] { x, y, z, r };
+	}
+
+	/**
+	 * Full geocentric position by the second method, from the elements, the mean
+	 * anomaly for the instant, the Sun's geocentric rectangular equatorial
+	 * coordinates {@code X, Y, Z} referred to the same standard equinox, and the
+	 * obliquity of that equinox. Formulae (25.14)&ndash;(25.15) plus the
+	 * elongation and phase angle of page 120. The right ascension and declination
+	 * are referred to the elements' standard equinox.
+	 */
+	public static OrbitPosition secondMethod(OrbitalElements elements, double meanAnomalyDegrees,
+			double sunX, double sunY, double sunZ, double obliquityDegrees) {
+		double[] xyzr = heliocentricEquatorialRectangular(elements, meanAnomalyDegrees,
+				obliquityDegrees);
+		double x = xyzr[0];
+		double y = xyzr[1];
+		double z = xyzr[2];
+		double r = xyzr[3];
+		double xi = sunX + x;
+		double eta = sunY + y;
+		double zeta = sunZ + z;
+		double alpha = normalize(toDegrees(atan2(eta, xi)));                       // (25.15)
+		double delta = sqrt(xi * xi + eta * eta + zeta * zeta);
+		double dec = toDegrees(asin(zeta / delta));
+		double sunR = sqrt(sunX * sunX + sunY * sunY + sunZ * sunZ);
+		double elongation = elongation(r, delta, sunR);
+		double phase = phaseAngle(r, delta, sunR);
+		return new OrbitPosition(new EquatorialCoordinates(alpha, dec), r, delta, elongation,
+				phase);
+	}
+
+	/**
+	 * Convenience overload of the second method that takes the Sun's rectangular
+	 * coordinates from the engine (chapter 19), reduced to the given standard
+	 * equinox, and computes the mean anomaly from the elements for the instant.
+	 *
+	 * @param engine the ephemeris engine (chapter 19 Sun).
+	 * @param julianDay the instant, as a Julian Day (Ephemeris Time).
+	 * @param elements the orbital elements (referred to {@code standardEquinox}).
+	 * @param standardEquinox the standard equinox of the elements (e.g. 1950.0).
+	 * @param obliquityDegrees the obliquity of that equinox (e.g. 23.4457889 for
+	 *            1950.0).
+	 */
+	public static OrbitPosition secondMethod(EphemerisEngine engine, double julianDay,
+			OrbitalElements elements, double standardEquinox, double obliquityDegrees) {
+		double[] sun = engine.sunRectangularEquatorialCoordinates(julianDay, standardEquinox);
+		double M = elements.meanAnomalyAt(julianDay);
+		return secondMethod(elements, M, sun[0], sun[1], sun[2], obliquityDegrees);
+	}
+
+	/**
+	 * The second method with the correction for light-time (25.10) applied: the
+	 * body is taken at the retarded instant {@code t - tau} while the Sun is kept
+	 * at {@code t}, iterating until {@code tau} is stable. The result is the
+	 * astrometric place; nutation and aberration (chapter 16) are not applied.
+	 *
+	 * @param engine the ephemeris engine (chapter 19 Sun).
+	 * @param julianDay the instant of observation {@code t}, as a Julian Day (ET).
+	 * @param elements the orbital elements (referred to {@code standardEquinox}).
+	 * @param standardEquinox the standard equinox of the elements.
+	 * @param obliquityDegrees the obliquity of that equinox.
+	 */
+	public static OrbitPosition secondMethodLightTimeCorrected(EphemerisEngine engine,
+			double julianDay, OrbitalElements elements, double standardEquinox,
+			double obliquityDegrees) {
+		double[] sun = engine.sunRectangularEquatorialCoordinates(julianDay, standardEquinox);
+		double tau = 0d;
+		OrbitPosition position = null;
+		for (int iteration = 0; iteration < 10; iteration++) {
+			double M = elements.meanAnomalyAt(julianDay - tau);
+			position = secondMethod(elements, M, sun[0], sun[1], sun[2], obliquityDegrees);
+			double newTau = LIGHT_TIME_CONSTANT * position.distanceToEarthAU();
+			if (Math.abs(newTau - tau) < 1e-9d) {
+				tau = newTau;
+				break;
+			}
+			tau = newTau;
+		}
+		return position;
+	}
+
+	/* --------------------------------------------------------------------- */
+	/* Magnitudes (formula 25.16 and the minor-planet relation, page 120).    */
+	/* --------------------------------------------------------------------- */
+
+	/**
+	 * Total magnitude of a comet, formula (25.16):
+	 * {@code m = g + 5 log Delta + kappa log r}.
+	 *
+	 * @param absoluteMagnitude the comet's absolute magnitude {@code g}.
+	 * @param earthDistanceAU the geocentric distance {@code Delta}, in AU.
+	 * @param radiusVectorAU the heliocentric distance {@code r}, in AU.
+	 * @param kappa the comet's brightness constant (typically 5 to 15).
+	 * @return the total magnitude.
+	 */
+	public static double cometTotalMagnitude(double absoluteMagnitude, double earthDistanceAU,
+			double radiusVectorAU, double kappa) {
+		return absoluteMagnitude + 5d * log10(earthDistanceAU) + kappa * log10(radiusVectorAU);
+	}
+
+	/**
+	 * Magnitude of a minor planet, page 120:
+	 * {@code m = g + 5 log(r*Delta) + k*beta}, with {@code beta} the phase angle
+	 * in degrees and {@code k} the phase coefficient (typically 0.023).
+	 *
+	 * @param absoluteMagnitude the absolute magnitude {@code g}.
+	 * @param radiusVectorAU the heliocentric distance {@code r}, in AU.
+	 * @param earthDistanceAU the geocentric distance {@code Delta}, in AU.
+	 * @param phaseAngleDegrees the phase angle {@code beta}, in degrees.
+	 * @param phaseCoefficient the phase coefficient {@code k}.
+	 * @return the magnitude.
+	 */
+	public static double minorPlanetMagnitude(double absoluteMagnitude, double radiusVectorAU,
+			double earthDistanceAU, double phaseAngleDegrees, double phaseCoefficient) {
+		return absoluteMagnitude + 5d * log10(radiusVectorAU * earthDistanceAU)
+				+ phaseCoefficient * phaseAngleDegrees;
+	}
+
+	/* --------------------------------------------------------------------- */
+	/* Internal helpers.                                                      */
+	/* --------------------------------------------------------------------- */
+
+	/**
+	 * Converts ecliptical longitude/latitude to equatorial right
+	 * ascension/declination with formulae (8.3)/(8.4), using the supplied
+	 * obliquity (of the date for the first method). Both inputs and outputs are
+	 * in degrees; the right ascension is normalised to [0, 360).
+	 */
+	private static EquatorialCoordinates eclipticToEquatorial(double longitudeDegrees,
+			double latitudeDegrees, double obliquityDegrees) {
+		double lambda = toRadians(longitudeDegrees);
+		double beta = toRadians(latitudeDegrees);
+		double eps = toRadians(obliquityDegrees);
+		double alpha = normalize(toDegrees(atan2(
+				sin(lambda) * cos(eps) - tan(beta) * sin(eps), cos(lambda))));     // (8.3)
+		double dec = toDegrees(asin(
+				sin(beta) * cos(eps) + cos(beta) * sin(eps) * sin(lambda)));       // (8.4)
+		return new EquatorialCoordinates(alpha, dec);
+	}
+
+	/** Elongation psi from the Sun, page 120: cos psi = (R^2 + D^2 - r^2)/(2 R D). */
+	private static double elongation(double r, double delta, double sunR) {
+		double cosPsi = (sunR * sunR + delta * delta - r * r) / (2d * sunR * delta);
+		return toDegrees(acos(clamp(cosPsi)));
+	}
+
+	/** Phase angle (Sun-body-Earth), page 120: cos beta = (r^2 + D^2 - R^2)/(2 r D). */
+	private static double phaseAngle(double r, double delta, double sunR) {
+		double cosBeta = (r * r + delta * delta - sunR * sunR) / (2d * r * delta);
+		return toDegrees(acos(clamp(cosBeta)));
+	}
+
+	private static double clamp(double cosine) {
+		if (cosine > 1d) {
+			return 1d;
+		}
+		if (cosine < -1d) {
+			return -1d;
+		}
+		return cosine;
+	}
+
+	private static double normalize(double degrees) {
+		double d = degrees % 360d;
+		if (d < 0d) {
+			d += 360d;
+		}
+		return d;
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/OrbitPosition.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/OrbitPosition.java
@@ -1,0 +1,38 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
+
+/**
+ * The computed geocentric position of a planet, minor planet or comet, as
+ * produced by {@link EllipticMotion}.
+ * <p>
+ * The {@link #equatorial() equatorial coordinates} carry the right ascension
+ * (in degrees) and declination (in degrees), referred to the same equinox as
+ * the orbital elements that produced them (the mean equinox of the date for the
+ * first method; the chosen standard equinox for the second method). The
+ * remaining fields are the heliocentric distance {@code r} and geocentric
+ * distance {@code Delta} (both in astronomical units), the elongation from the
+ * Sun {@code psi} and the phase angle (Sun&ndash;body&ndash;Earth), both in
+ * degrees and both in the range [0, 180].
+ *
+ * @param equatorial the geocentric right ascension (degrees) and declination
+ *            (degrees).
+ * @param radiusVectorAU the heliocentric distance {@code r}, in AU.
+ * @param distanceToEarthAU the geocentric distance {@code Delta}, in AU.
+ * @param elongationDegrees the elongation from the Sun {@code psi}, in degrees.
+ * @param phaseAngleDegrees the phase angle (Sun&ndash;body&ndash;Earth), in
+ *            degrees.
+ */
+public record OrbitPosition(EquatorialCoordinates equatorial, double radiusVectorAU,
+		double distanceToEarthAU, double elongationDegrees, double phaseAngleDegrees) {
+
+	/** Convenience accessor for the right ascension, in degrees. */
+	public double rightAscensionDegrees() {
+		return equatorial.getRightAscension();
+	}
+
+	/** Convenience accessor for the declination, in degrees. */
+	public double declinationDegrees() {
+		return equatorial.getDeclinaison();
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/OrbitalElements.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/OrbitalElements.java
@@ -1,0 +1,117 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static java.lang.Math.sqrt;
+
+/**
+ * The classical (Keplerian) orbital elements of a minor planet or periodic
+ * comet, referred to a standard equinox, as used by the <i>second method</i> of
+ * chapter 25 of Jean Meeus' <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * The element set is {@code a, e, i, omega, Omega} together with a description
+ * of the body's position along the orbit at a reference instant: the mean
+ * anomaly {@code M0} at an epoch, plus the daily mean motion {@code n}. The mean
+ * anomaly at any other instant is then {@code M = M0 + n*(jd - epochJd)}
+ * (it increases by {@code n} degrees per day and is zero at perihelion).
+ * <p>
+ * Angles are in degrees, {@code a} is in astronomical units and {@code n} in
+ * degrees per day. The orientation angles {@code i, omega, Omega} are referred
+ * to whatever standard equinox the caller works in (typically 1950.0); the
+ * engine reduces the Sun's rectangular coordinates to that same equinox, so the
+ * resulting right ascension and declination come out referred to it. Keeping the
+ * elements and the Sun on the same equinox is the caller's responsibility — the
+ * one hard rule of chapter 25's second method.
+ *
+ * @param semiMajorAxisAU the semimajor axis {@code a}, in astronomical units.
+ * @param eccentricity the orbital eccentricity {@code e} (0 &le; e &lt; 1).
+ * @param inclinationDegrees the inclination {@code i}, in degrees.
+ * @param argumentOfPerihelionDegrees the argument of perihelion {@code omega},
+ *            in degrees.
+ * @param ascendingNodeLongitudeDegrees the longitude of the ascending node
+ *            {@code Omega}, in degrees.
+ * @param epochJulianDay the Julian Day of the epoch at which {@code M0} holds.
+ * @param meanAnomalyAtEpochDegrees the mean anomaly {@code M0} at the epoch, in
+ *            degrees.
+ * @param meanMotionDegreesPerDay the daily mean motion {@code n}, in degrees per
+ *            day.
+ */
+public record OrbitalElements(double semiMajorAxisAU, double eccentricity,
+		double inclinationDegrees, double argumentOfPerihelionDegrees,
+		double ascendingNodeLongitudeDegrees, double epochJulianDay,
+		double meanAnomalyAtEpochDegrees, double meanMotionDegreesPerDay) {
+
+	/** Gaussian-derived constant of formula (25.12): n = 0.985609 / (a*sqrt(a)). */
+	private static final double MEAN_MOTION_CONSTANT = 0.985609d;
+
+	/**
+	 * Mean motion derived from the semimajor axis with formula (25.12),
+	 * {@code n = 0.985609 / (a*sqrt(a))}, in degrees per day. Useful when the
+	 * orbit is supplied with {@code a} but no explicit {@code n}.
+	 *
+	 * @param semiMajorAxisAU the semimajor axis, in astronomical units.
+	 * @return the mean motion, in degrees per day.
+	 */
+	public static double meanMotionFromSemiMajorAxis(double semiMajorAxisAU) {
+		return MEAN_MOTION_CONSTANT / (semiMajorAxisAU * sqrt(semiMajorAxisAU));
+	}
+
+	/**
+	 * Semimajor axis derived from the perihelion distance with formula (25.12),
+	 * {@code a = q / (1 - e)}.
+	 *
+	 * @param perihelionDistanceAU the perihelion distance {@code q}, in AU.
+	 * @param eccentricity the orbital eccentricity {@code e}.
+	 * @return the semimajor axis, in astronomical units.
+	 */
+	public static double semiMajorAxisFromPerihelionDistance(double perihelionDistanceAU,
+			double eccentricity) {
+		return perihelionDistanceAU / (1d - eccentricity);
+	}
+
+	/**
+	 * Builds an element set from a mean anomaly given at an epoch, with an
+	 * explicit mean motion.
+	 */
+	public static OrbitalElements fromMeanAnomalyAtEpoch(double a, double e, double i,
+			double omega, double node, double epochJulianDay, double meanAnomalyAtEpoch,
+			double meanMotion) {
+		return new OrbitalElements(a, e, i, omega, node, epochJulianDay,
+				meanAnomalyAtEpoch, meanMotion);
+	}
+
+	/**
+	 * Builds an element set from a mean anomaly given at an epoch, deriving the
+	 * mean motion from the semimajor axis with formula (25.12).
+	 */
+	public static OrbitalElements fromMeanAnomalyAtEpoch(double a, double e, double i,
+			double omega, double node, double epochJulianDay, double meanAnomalyAtEpoch) {
+		return new OrbitalElements(a, e, i, omega, node, epochJulianDay,
+				meanAnomalyAtEpoch, meanMotionFromSemiMajorAxis(a));
+	}
+
+	/**
+	 * Builds an element set from a time of perihelion passage. The mean anomaly
+	 * is zero at that instant, so the epoch is the perihelion instant and
+	 * {@code M0 = 0}.
+	 */
+	public static OrbitalElements fromPerihelionPassage(double a, double e, double i,
+			double omega, double node, double perihelionJulianDay, double meanMotion) {
+		return new OrbitalElements(a, e, i, omega, node, perihelionJulianDay, 0d, meanMotion);
+	}
+
+	/**
+	 * The mean anomaly at the given instant, {@code M = M0 + n*(jd - epochJd)},
+	 * normalised to the range [0, 360) degrees.
+	 *
+	 * @param julianDay the instant, as a Julian Day (Ephemeris Time).
+	 * @return the mean anomaly, in degrees, in [0, 360).
+	 */
+	public double meanAnomalyAt(double julianDay) {
+		double m = meanAnomalyAtEpochDegrees
+				+ meanMotionDegreesPerDay * (julianDay - epochJulianDay);
+		m %= 360d;
+		if (m < 0d) {
+			m += 360d;
+		}
+		return m;
+	}
+}

--- a/src/test/java/com/nzv/astro/ephemeris/orbit/EllipticMotionTest.java
+++ b/src/test/java/com/nzv/astro/ephemeris/orbit/EllipticMotionTest.java
@@ -1,0 +1,223 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.nzv.astro.ephemeris.EphemerisEngine;
+import com.nzv.astro.ephemeris.impl.EphemerisEngineImpl;
+
+/**
+ * Validates the chapter-25 elliptic-motion engine against the chapter's two
+ * worked examples and the chapter's published-ephemeris exercise.
+ * <p>
+ * Following the project's two-tier discipline, the pure geometry is first
+ * checked against the book's own printed inputs and intermediates (tight
+ * tolerances), then the {@code julianDay} convenience overloads are checked
+ * end-to-end through the library's own Sun (looser tolerances, with the computed
+ * value pinned as a regression anchor).
+ */
+public class EllipticMotionTest {
+
+	private static final EphemerisEngine ENGINE = new EphemerisEngineImpl();
+
+	/** Standard equinox 1950.0 and its obliquity, used by example 25.b (page 118). */
+	private static final double EQUINOX_1950 = 1950.0d;
+	private static final double OBLIQUITY_1950 = 23.4457889d;
+
+	/* ===================== Example 25.a — first method ===================== */
+
+	@Test
+	public void firstMethodReproducesHeliocentricExample25a() {
+		// Mercury, 1978 November 12.0 ET. Book inputs.
+		double[] lbr = EllipticMotion.heliocentricEcliptic(337.053200d, 0.3870986d, 0.20563033d,
+				7.004337d, 48.080736d, 259.92660d);
+		assertEquals("l", 315.35697d, lbr[0], 5e-4d);
+		assertEquals("b", -6.99650d, lbr[1], 5e-4d);
+		assertEquals("r", 0.41571d, lbr[2], 5e-5d);
+	}
+
+	@Test
+	public void firstMethodReproducesGeocentricExample25a() {
+		// Heliocentric l, b, r and Sun (Theta, R) taken from the book.
+		double[] geo = EllipticMotion.geocentricEcliptic(315.35697d, -6.99650d, 0.41571d,
+				229.25049d, 0.98984d);
+		assertEquals("lambda", 251.27086d, geo[0], 2e-3d);
+		assertEquals("beta", -2.64058d, geo[1], 2e-3d);
+		assertEquals("Delta", 1.09912d, geo[2], 5e-5d);
+	}
+
+	@Test
+	public void firstMethodReproducesEquatorialExample25a() {
+		// Full first method on the book's inputs (Theta, R, epsilon of date).
+		OrbitPosition p = EllipticMotion.firstMethod(337.053200d, 0.3870986d, 0.20563033d,
+				7.004337d, 48.080736d, 259.92660d, 229.25049d, 0.98984d, 23.442032d);
+		assertEquals("alpha", 249.31740d, p.rightAscensionDegrees(), 2e-3d);
+		assertEquals("delta", -24.74770d, p.declinationDegrees(), 2e-3d);
+		assertEquals("Delta", 1.09912d, p.distanceToEarthAU(), 5e-5d);
+		assertEquals("r", 0.41571d, p.radiusVectorAU(), 5e-5d);
+		assertEquals("psi", 22.17d, p.elongationDegrees(), 1e-2d);
+	}
+
+	@Test
+	public void firstMethodFromEngineReproducesExample25a() {
+		// julianDay overload: Sun and obliquity come from the library itself.
+		double jd = 2443824.5d; // 1978 November 12.0 ET
+		OrbitPosition p = EllipticMotion.firstMethod(ENGINE, jd, 337.053200d, 0.3870986d,
+				0.20563033d, 7.004337d, 48.080736d, 259.92660d);
+		// The library reproduces Theta, R and epsilon to the book's precision, so
+		// the end-to-end position matches the book closely.
+		assertEquals("alpha", 249.31740d, p.rightAscensionDegrees(), 5e-3d);
+		assertEquals("delta", -24.74770d, p.declinationDegrees(), 5e-3d);
+		// Regression anchor at the engine's JD-derived T.
+		assertEquals("alpha pinned", 249.317559d, p.rightAscensionDegrees(), 5e-4d);
+		assertEquals("delta pinned", -24.747739d, p.declinationDegrees(), 5e-4d);
+	}
+
+	/* ===================== Example 25.b — second method ==================== */
+
+	@Test
+	public void gaussianConstantsReproduceExample25b() {
+		double[] g = EllipticMotion.gaussianConstants(303.83085d, 10.82772d, OBLIQUITY_1950);
+		// a, b, c (magnitudes) then A, B, C (angles).
+		assertEquals("a", 0.98774923d, g[0], 1e-7d);
+		assertEquals("b", 0.87354119d, g[1], 1e-7d);
+		assertEquals("c", 0.51115287d, g[2], 1e-7d);
+		assertEquals("A", 34.30847d, g[3], 1e-4d);
+		assertEquals("B", -60.74191d, g[4], 1e-4d);
+		assertEquals("C", -40.28610d, g[5], 1e-4d);
+	}
+
+	@Test
+	public void secondMethodReproducesRectangularExample25b() {
+		// 433 Eros, 1975 February 11.0 ET. M from the book (17.29550 days * n).
+		OrbitalElements eros = OrbitalElements.fromPerihelionPassage(1.4579641d, 0.2227021d,
+				10.82772d, 178.44991d, 303.83085d, /*perihelion*/ 0d, 0.55986565d);
+		double M = 17.29550d * 0.55986565d; // = 9.683156 degrees
+		double[] xyzr = EllipticMotion.heliocentricEquatorialRectangular(eros, M, OBLIQUITY_1950);
+		assertEquals("x", -0.8415580d, xyzr[0], 5e-7d);
+		assertEquals("y", 0.7257529d, xyzr[1], 5e-7d);
+		assertEquals("z", 0.2582179d, xyzr[2], 5e-7d);
+		assertEquals("r", 1.1408828d, xyzr[3], 5e-7d);
+	}
+
+	@Test
+	public void secondMethodReproducesEquatorialExample25b() {
+		// Geometry against the book's printed Sun X, Y, Z (1950.0).
+		OrbitalElements eros = OrbitalElements.fromPerihelionPassage(1.4579641d, 0.2227021d,
+				10.82772d, 178.44991d, 303.83085d, 0d, 0.55986565d);
+		double M = 17.29550d * 0.55986565d;
+		OrbitPosition p = EllipticMotion.secondMethod(eros, M, 0.7700006d, -0.5664014d,
+				-0.2456064d, OBLIQUITY_1950);
+		assertEquals("alpha", 114.182647d, p.rightAscensionDegrees(), 1e-3d);
+		assertEquals("delta", 4.130d, p.declinationDegrees(), 2e-3d);
+		assertEquals("Delta", 0.1751354d, p.distanceToEarthAU(), 5e-7d);
+		assertEquals("r", 1.1408828d, p.radiusVectorAU(), 5e-7d);
+		assertEquals("psi", 149.19d, p.elongationDegrees(), 1e-2d);
+		assertEquals("phase", 26.30d, p.phaseAngleDegrees(), 1e-2d);
+	}
+
+	@Test
+	public void secondMethodMinorPlanetMagnitudeReproducesExample25b() {
+		double m = EllipticMotion.minorPlanetMagnitude(12.4d, 1.1408828d, 0.1751354d, 26.30d,
+				0.023d);
+		assertEquals("magnitude", 9.5d, m, 5e-2d);
+	}
+
+	@Test
+	public void secondMethodFromEngineApproximatesExample25b() {
+		// julianDay + light-time overload: Sun X, Y, Z come from chapter 19, which
+		// differs from the A.E. by the known ~1e-4 AU precession residual, so the
+		// agreement with the book is looser. The computed value is pinned.
+		// julianDay + light-time overload: Sun X, Y, Z come from chapter 19, which
+		// differs from the A.E. by the known ~1e-4 AU precession residual. Because
+		// Eros is near the Earth here (Delta = 0.175 AU), that small absolute error
+		// is angularly amplified to ~0.04 degree, so the agreement with the book is
+		// necessarily loose; the computed value is pinned as the regression anchor.
+		double jd = 2442454.5d; // 1975 February 11.0 ET
+		OrbitalElements eros = OrbitalElements.fromPerihelionPassage(1.4579641d, 0.2227021d,
+				10.82772d, 178.44991d, 303.83085d,
+				/*perihelion JD 1975 Jan 24.70450 ET*/ 2442437.20450d, 0.55986565d);
+		OrbitPosition p = EllipticMotion.secondMethodLightTimeCorrected(ENGINE, jd, eros,
+				EQUINOX_1950, OBLIQUITY_1950);
+		assertEquals("alpha vs book", 114.182647d, p.rightAscensionDegrees(), 5e-2d);
+		assertEquals("delta vs book", 4.130d, p.declinationDegrees(), 5e-2d);
+		// Regression anchors (engine Sun + light-time).
+		assertEquals("alpha pinned", 114.146667d, p.rightAscensionDegrees(), 5e-4d);
+		assertEquals("delta pinned", 4.142939d, p.declinationDegrees(), 5e-4d);
+	}
+
+	/* ============ Published-ephemeris exercise — minor planet 234 Barbara === */
+
+	@Test
+	public void secondMethodMatchesPublishedEphemerisForBarbara() {
+		// Elements at epoch 1979 November 23.0 ET (JD 2444200.5), equinox 1950.0.
+		OrbitalElements barbara = OrbitalElements.fromMeanAnomalyAtEpoch(2.3848264d, 0.2456180d,
+				15.38354d, 191.11341d, 144.17952d, 2444200.5d, 34.88670d, 0.26762022d);
+
+		// Ephemerides of Minor Planets for 1979 (Leningrad, 1978), 0h ET.
+		// 1979 Sept 24: alpha 1h21.0m, delta -15deg04'.
+		assertPosition(barbara, 2444140.5d, hms(1, 21.0d), dms(-15, 4d), 4e-2d);
+		// 1979 Oct 14: alpha 1h08.4m, delta -19deg15'.
+		assertPosition(barbara, 2444160.5d, hms(1, 8.4d), dms(-19, 15d), 4e-2d);
+		// 1979 Nov 3: alpha 0h57.9m, delta -20deg17'.
+		assertPosition(barbara, 2444180.5d, hms(0, 57.9d), dms(-20, 17d), 4e-2d);
+	}
+
+	private void assertPosition(OrbitalElements el, double jd, double expectedAlpha,
+			double expectedDelta, double tolerance) {
+		OrbitPosition p = EllipticMotion.secondMethodLightTimeCorrected(ENGINE, jd, el,
+				EQUINOX_1950, OBLIQUITY_1950);
+		assertEquals("alpha @ " + jd, expectedAlpha, p.rightAscensionDegrees(), tolerance);
+		assertEquals("delta @ " + jd, expectedDelta, p.declinationDegrees(), tolerance);
+	}
+
+	/* ===================== Light-time and element helpers ================== */
+
+	@Test
+	public void lightTimeShiftsThePositionSlightly() {
+		double jd = 2442454.5d;
+		OrbitalElements eros = OrbitalElements.fromPerihelionPassage(1.4579641d, 0.2227021d,
+				10.82772d, 178.44991d, 303.83085d, 2442437.20450d, 0.55986565d);
+		double[] sun = ENGINE.sunRectangularEquatorialCoordinates(jd, EQUINOX_1950);
+		OrbitPosition geometric = EllipticMotion.secondMethod(eros, eros.meanAnomalyAt(jd),
+				sun[0], sun[1], sun[2], OBLIQUITY_1950);
+		OrbitPosition corrected = EllipticMotion.secondMethodLightTimeCorrected(ENGINE, jd, eros,
+				EQUINOX_1950, OBLIQUITY_1950);
+		double shift = Math.abs(corrected.rightAscensionDegrees()
+				- geometric.rightAscensionDegrees());
+		// tau = 0.0057756 * Delta ~ 0.001 day at Delta = 0.175 AU; the position moves
+		// by a small but non-zero amount.
+		assertTrue("light-time produces a non-zero shift", shift > 0d);
+		assertTrue("light-time shift is small", shift < 0.01d);
+	}
+
+	@Test
+	public void meanAnomalyAdvancesWithMeanMotion() {
+		OrbitalElements el = OrbitalElements.fromMeanAnomalyAtEpoch(2d, 0.1d, 5d, 10d, 20d,
+				2444200.5d, 30d, 0.5d);
+		assertEquals(30d, el.meanAnomalyAt(2444200.5d), 1e-9d);
+		assertEquals(35d, el.meanAnomalyAt(2444210.5d), 1e-9d); // +10 days * 0.5/day
+	}
+
+	@Test
+	public void meanMotionFromSemiMajorAxisMatchesFormula2512() {
+		// Eros: a = 1.4579641 -> n ~ 0.55987 deg/day.
+		double n = OrbitalElements.meanMotionFromSemiMajorAxis(1.4579641d);
+		assertEquals(0.559866d, n, 5e-6d);
+	}
+
+	/* ============================ small helpers ============================ */
+
+	/** Right ascension in degrees from hours and decimal minutes. */
+	private static double hms(int hours, double minutes) {
+		return (hours + minutes / 60d) * 15d;
+	}
+
+	/** Declination in degrees from (signed) degrees and arcminutes. */
+	private static double dms(int degrees, double arcminutes) {
+		double sign = degrees < 0 ? -1d : 1d;
+		return sign * (Math.abs(degrees) + arcminutes / 60d);
+	}
+}


### PR DESCRIPTION
Add the elliptic-motion engine, the keystone that turns orbital elements into a geocentric position and is reused by every later planet and minor-body chapter. It is algorithm-bound and table-free — it consumes caller-supplied OrbitalElements — so it ships independently of the Ch 23/24 planetary-data track and runs in parallel with it (Planets & Minor Bodies proposal, Option C).

New package com.nzv.astro.ephemeris.orbit:

* EllipticMotion (static utility) — both methods of the chapter:
  - First method (major planets, mean equinox of date): heliocentricEcliptic (25.1-25.6), geocentricEcliptic (25.7-25.9), firstMethod(...), plus a julianDay overload taking the Sun's geometric longitude, radius vector and the obliquity of date from the engine (Ch 18).
  - Second method (minor planets/comets, standard-equinox elements): gaussianConstants (25.13), heliocentricEquatorialRectangular (25.14), secondMethod(...) (25.15) reusing sunRectangularEquatorialCoordinates(jd, equinox) (Ch 19), and secondMethodLightTimeCorrected(...) applying the light-time correction (25.10).
  - Elongation and phase angle on every result; comet (25.16) and minor-planet magnitude helpers.
* OrbitalElements (record) — classical elements a,e,i,omega,Omega plus a mean anomaly at an epoch and daily mean motion; meanAnomalyAt(jd); factories fromMeanAnomalyAtEpoch / fromPerihelionPassage; meanMotionFromSemiMajorAxis (25.12) and semiMajorAxisFromPerihelionDistance.
* OrbitPosition (record) — RA/Dec (degrees), r, Delta, elongation, phase angle.

Positions are geometric (as the chapter's worked examples are), plus the light-time/astrometric correction; nutation and aberration onto a fully apparent place (Ch 16) are left to the caller.

Reuses the Ch 22 Kepler solver and the Ch 19 Sun; no edits to the existing
interface, so the change is purely additive. Note: the of-date ecliptic ->
equatorial conversion uses the obliquity of date, not the 1950.0-hardwired EclipticCoordinatesAdapter.

Validation (13 new tests, suite 108 -> 121):
* Example 25.a (Mercury, first method) — heliocentric l,b,r, geocentric lambda,beta,Delta and equatorial alpha,delta of date reproduce the book to printed precision; the julianDay overload reproduces it to ~1e-4 deg.
* Example 25.b (433 Eros, second method) — Gaussian constants, x,y,z, Delta, alpha/delta (1950.0), elongation, phase angle and magnitude reproduce the book against its printed Sun X,Y,Z; through the Ch 19 Sun the agreement is ~0.04 deg (the near-Earth geometry amplifies the known ~1e-4 AU equinox residual) and is pinned.
* Minor planet 234 Barbara (chapter exercise) — matches the published Ephemerides of Minor Planets for 1979 to <=0.012 deg.

Docs: CHANGELOG, REFCARD (new section 17), coverage report (Ch 25 0% -> 95%) and the phased plan (new Phase 4) updated; pom 1.7.0 -> 1.8.0.