### PR TITLE
Phase 4 (step 2): Chapter 26 — Parabolic-motion engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 1.9.0 — Phase 4 (step 2): Parabolic-motion engine (Chapter 26)
+
+This release adds the **parabolic-motion engine** (Chapter 26) — geocentric positions of comets in
+parabolic orbits — and factors out the geocentric-reduction tail now shared with Chapter 25. Like
+the elliptic engine it is algorithm-bound and table-free. The suite grows from 121 to 131 tests, all
+passing.
+
+### New features
+
+- **Chapter 26 — Parabolic Motion.** New classes in `com.nzv.astro.ephemeris.orbit`:
+  - **`BarkerEquation`** — solves `s³ + 3s − W = 0` (26.3) for `s = tan(v/2)`, with the coefficient
+    `W` (26.1), both solving methods of the chapter — the iteration (26.4, the recommended default)
+    and the closed form (26.5, after Bauschinger) — and the true anomaly / radius vector (26.2). It
+    is to parabolic orbits what `KeplerEquation` is to elliptic ones (a parabola has `e = 1`, so the
+    equation of Kepler does not apply).
+  - **`ParabolicElements`** record — `q, i, ω, Ω, T` (perihelion distance, orientation, and time of
+    perihelion passage), with `daysSincePerihelion(jd)`.
+  - **`ParabolicMotion`** — `geocentricPosition(...)` (static and `julianDay` overloads) and
+    `lightTimeCorrected(...)`. The reduction reuses the Chapter-25 Gaussian constants (25.13), the
+    heliocentric rectangular coordinates (25.14) and the Sun combination (25.15), and the Chapter-19
+    Sun. Comet total magnitude (25.16) is already available on `EllipticMotion`.
+
+### Internal
+
+- **Shared geocentric reduction.** The `{x, y, z, r} + Sun → OrbitPosition` tail (25.14/25.15 plus
+  the elongation and phase angle) is extracted into a package-private `GeocentricReduction` helper
+  and reused by both the elliptic second method and the parabolic engine. Behaviour-preserving — the
+  existing Chapter-25 tests are unchanged and still pass.
+
+### Validation
+
+- **Example 26.a** (comet Kohler 1977m): the coefficient `W`, the root `s` by **both** solving
+  methods, the true anomaly `v`, radius vector `r`, the equatorial `α₁₉₅₀`/`δ₁₉₅₀`, Earth distance
+  `Δ`, elongation and total magnitude all reproduce the book to its printed precision against its
+  printed Sun `X, Y, Z`. Through the library's Chapter-19 Sun and the light-time correction the
+  agreement is ~0.004° and the value is pinned.
+
 ## 1.8.0 — Phase 4 (step 1): Elliptic-motion engine (Chapter 25)
 
 This release adds the **elliptic-motion engine** (Chapter 25), the keystone that turns orbital

--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -52,6 +52,13 @@
 > light-time correction available; nutation/aberration onto a fully apparent place (Chapter 16) are
 > left to the caller, hence 95% rather than 100%. No table data is involved — this is the engine the
 > data-bound planetary track (Chapters 23/24) will feed later.
+>
+> **Version note (1.9.0):** Phase 4, step 2 is complete. **26 Parabolic Motion** moves 0% → 95%:
+> new `BarkerEquation` (solves `s³ + 3s − W = 0` for `s = tan(v/2)`, both the iteration and the
+> closed-form methods), `ParabolicElements` and `ParabolicMotion` reuse the Chapter-25 geocentric
+> reduction (now factored into a shared `GeocentricReduction` helper) and the Chapter-19 Sun.
+> Validated on Example 26.a (comet Kohler 1977m) to the book's printed precision. Geometric +
+> light-time, same as Ch 25; suite 121 → 131 tests.
 
 > **Version note (1.3.0):** Phase 2, step 1 (the star keystone) is complete.
 > **16 Apparent Place of a Star** moves 25% → 95%: proper motion, precession, nutation
@@ -117,7 +124,7 @@ utilities beyond the reference edition.
 | 23 | Elements of the Planetary Orbits | MEDIUM | `░░░░░░░░░░` 0% |
 | 24 | Planets: Principal Perturbations | HIGH | `░░░░░░░░░░` 0% |
 | 25 | Elliptic Motion | HIGH | `█████████░` 95% |
-| 26 | Parabolic Motion | MEDIUM | `░░░░░░░░░░` 0% |
+| 26 | Parabolic Motion | MEDIUM | `█████████░` 95% |
 | 27 | Planets in Perihelion and Aphelion | MEDIUM | `░░░░░░░░░░` 0% |
 | 28 | Passages Through the Nodes | MEDIUM | `░░░░░░░░░░` 0% |
 | 29 | Correction for Parallax | MEDIUM | `██████████` 100% |
@@ -272,10 +279,10 @@ to be authored next (inner planets → Jupiter/Saturn).
 **Applications.** Positions of planets and elliptical-orbit minor planets and comets.
 **Coverage.** Implemented in `com.nzv.astro.ephemeris.orbit` (`EllipticMotion`, `OrbitalElements`, `OrbitPosition`). First method (major planets, mean equinox of date) and second method (minor planets/comets, standard-equinox elements, reusing the Chapter-19 Sun and the Chapter-22 Kepler solver), driven by caller-supplied elements. Geometric positions plus elongation, phase angle, light-time correction (25.10) and the magnitude relations (25.16). Validated on Examples 25.a (Mercury) and 25.b (433 Eros) and the 234 Barbara published-ephemeris exercise. The remaining 5% is nutation/aberration onto a fully apparent place (Chapter 16), deliberately left to the caller.
 
-### 26 — Parabolic Motion · Complexity: MEDIUM · `░░░░░░░░░░` 0%
-**Formulae.** Position of a body on a parabolic orbit (Barker's equation).
+### 26 — Parabolic Motion · Complexity: MEDIUM · `█████████░` 95%
+**Formulae.** Position of a comet on a parabolic orbit: Barker's equation `s³ + 3s − W = 0` (26.1–26.5) feeding the Chapter-25 geocentric reduction.
 **Applications.** Comet ephemerides.
-**Coverage.** Not implemented.
+**Coverage.** Implemented in `com.nzv.astro.ephemeris.orbit`: `BarkerEquation` (both the iteration 26.4 and closed-form 26.5 solving methods), `ParabolicElements` (`q, i, ω, Ω, T`) and `ParabolicMotion`, reusing the shared `GeocentricReduction` tail and the Chapter-19 Sun. Geometric positions plus elongation, phase angle, light-time correction and the comet magnitude relation (25.16). Validated on Example 26.a (comet Kohler 1977m). The remaining 5% is nutation/aberration onto a fully apparent place (Chapter 16), left to the caller — consistent with Chapter 25.
 
 ### 27 — Planets in Perihelion and Aphelion · Complexity: MEDIUM · `░░░░░░░░░░` 0%
 **Formulae.** Times and distances of perihelion/aphelion passage.

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -12,7 +12,7 @@
 | **2 — The two keystones** | ✅ **Done (v1.4.0)** | 16 ✅, 30 ✅ | Star keystone (16) and Moon keystone (30, table-driven series) both shipped. |
 | **3 — Harvest** | 🟦 In progress — steps 1–2 ✅, 3a ✅ (v1.5.0–v1.7.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 22 ✅, 29 ✅, 31 ✅, 32 ✅ · then 38 | Steps 1–2 and 3a (equation of Kepler) shipped, 82 → 108 tests. Step 3b (binary stars, Ch 38) is the last Harvest item. |
 | **4 — Planets & minor bodies** | 🟦 Committed (Option C); data-acquisition track started | 23–28, 34–36 | Parallel **data-acquisition side-track** live on `feat/phase-4-data-acquisition` (docs/masters only): Ch 23 elements ✅ transcribed & self-checked, Ch 24 perturbations next. See the proposal + data-acquisition tracker. |
-| **4 — Orbital-motion engine & minor bodies** | 🟦 In progress — step 1 ✅ (v1.8.0) | 25 ✅ · then 26, 27, 28, 36 | Elliptic-motion engine (Ch 25) shipped, 108 → 121 tests. Algorithm-bound, table-free; runs in parallel with the Ch 23/24 data-acquisition track. |
+| **4 — Orbital-motion engine & minor bodies** | 🟦 In progress — steps 1–2 ✅ (v1.8.0–v1.9.0) | 25 ✅, 26 ✅ · then 27, 28, 36 | Elliptic (Ch 25) and parabolic/comet (Ch 26) engines shipped, 108 → 131 tests. Algorithm-bound, table-free; runs in parallel with the Ch 23/24 data-acquisition track. |
 | *Deferred* | ⬜ Out of scope (data-bound) | Major-planet data (elements + perturbations) and Phase-5 derived phenomena. |
 
 **What changed in v1.2.0 (Phase 1):**
@@ -120,7 +120,7 @@ perturbations, staged per planet (inner → Jupiter/Saturn). Engine code (Ch 25)
 The keystone here is **Chapter 25 (Elliptic Motion)**: it turns orbital elements into a geocentric position and is reused by every later planet and minor-body chapter. It needs no perturbation tables — only the Chapter-22 Kepler solver ✅ and the Chapter-19 Sun ✅, both already in the library.
 
 - ✅ **Step 1 — Elliptic-motion engine (DONE, v1.8.0).** Ch 25, both methods, in the new `com.nzv.astro.ephemeris.orbit` package (`EllipticMotion`, `OrbitalElements`, `OrbitPosition`). The first method (major planets, mean equinox of date) forms heliocentric → geocentric ecliptic → equatorial of date; the second method (minor planets/comets, standard-equinox elements) forms heliocentric rectangular equatorial coordinates via the per-orbit Gaussian constants and reads RA/Dec directly off the Chapter-19 Sun, with a light-time correction. Geometric positions plus elongation, phase angle and the magnitude relations. Validated on Examples 25.a (Mercury) and 25.b (433 Eros) and the 234 Barbara published-ephemeris exercise; suite 108 → 121 tests.
-- ⬜ **Step 2 — Parabolic motion / comets (Ch 26).** Barker's equation (direct cubic, no iteration) feeding the same geocentric reduction. Self-contained, no tables; the best value-per-effort item left.
+- ✅ **Step 2 — Parabolic motion / comets (DONE, v1.9.0).** Ch 26: `BarkerEquation` solves `s³ + 3s − W = 0` for `s = tan(v/2)` (both the iteration 26.4 and the closed-form 26.5), feeding the **same** geocentric reduction as Ch 25 — now factored into a shared `GeocentricReduction` helper. `ParabolicMotion` + `ParabolicElements`. Validated on Example 26.a (comet Kohler 1977m); suite 121 → 131.
 - ⬜ **Step 3 — Light derived chapters (Ch 27, 28, 36).** Perihelion/aphelion instants, nodal passages and semidiameter, for caller-supplied elements/distances.
 
 **End-of-phase deliverable:** *"give me the apparent position of any comet or minor planet from its orbital elements,"* plus apsides, nodes and semidiameter — entirely algorithm-bound. The data-bound major-planet work (Ch 23 elements, Ch 24 perturbations on a `planetary` table package, Ch 34, Ch 10 capstone) is **Phase 5**, gated on the data-acquisition track now running in parallel.
@@ -143,5 +143,5 @@ The keystone here is **Chapter 25 (Elliptic Motion)**: it turns orbital elements
 | **2** | The two keystones | 16 ✅, 30 ✅ | High | ✅ Done (v1.4.0) | Both priority tracks' hard core |
 | **3** | Harvest | 13 ✅ 19 ✅ 20 ✅ 21 ✅ 22 ✅ 29 ✅ 31 ✅ 32 ✅ · then 38 | Low (post-keystone) | 🟦 Steps 1–2, 3a done (v1.5.0–v1.7.0) | The derived Moon and star phenomena |
 | **4** | Data acquisition | Planets & minor bodies (Option C) | 23–28, 34–36 | L (engine) + XL (Ch 24 data) | 🟦 Committed; data track started | Positions of comets, minor planets, and the major planets |
-| **4** | Orbital-motion engine | 25 ✅ · then 26, 27, 28, 36 | Medium (algorithm-bound) | 🟦 Step 1 done (v1.8.0) | Positions of comets & minor planets from elements |
+| **4** | Orbital-motion engine | 25 ✅ 26 ✅ · then 27, 28, 36 | Medium (algorithm-bound) | 🟦 Steps 1–2 done (v1.8.0–v1.9.0) | Positions of comets & minor planets from elements |
 | *Phase 5* | Major planets (data-bound) | 23, 24, 34, 10 | High | ⬜ | Built-in major-planet positions; gated on data acquisition |

--- a/REFCARD.md
+++ b/REFCARD.md
@@ -2,7 +2,7 @@
 
 ### The astronomical formulae of Jean Meeus, in Java
 
-> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Equation of Kepler &nbsp;·&nbsp; Elliptic Motion &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
+> **CONTENTS** &nbsp;·&nbsp; Conventions &nbsp;·&nbsp; Sexagesimal &nbsp;·&nbsp; Julian Day & Calendar &nbsp;·&nbsp; Sidereal Time &nbsp;·&nbsp; Delta-T / ET <-> UT &nbsp;·&nbsp; Sun & Moon Elements &nbsp;·&nbsp; Solar Coordinates &nbsp;·&nbsp; Nutation &nbsp;·&nbsp; Easter &nbsp;·&nbsp; Coordinate Systems &nbsp;·&nbsp; Precession &nbsp;·&nbsp; Angular Separation &nbsp;·&nbsp; Stellar Magnitudes &nbsp;·&nbsp; Rise / Transit / Set &nbsp;·&nbsp; Apparent Place of a Star &nbsp;·&nbsp; Position of the Moon &nbsp;·&nbsp; Atmospheric Refraction &nbsp;·&nbsp; Interpolation &nbsp;·&nbsp; Equation of Kepler &nbsp;·&nbsp; Elliptic Motion &nbsp;·&nbsp; Parabolic Motion &nbsp;·&nbsp; Constants &nbsp;·&nbsp; Build
 
 ---
 
@@ -557,7 +557,51 @@ OrbitPosition p = EllipticMotion.secondMethodLightTimeCorrected(
 
 ---
 
-## 18. Constants — `Constants`
+## 18. Parabolic Motion — `ParabolicMotion` / `ParabolicElements` / `BarkerEquation` (static, Ch. 26)
+
+`com.nzv.astro.ephemeris.orbit`. Geocentric position of a **comet** in a parabolic orbit. Same
+geocentric reduction as Ch. 25's second method, with **Barker's equation** in place of Kepler
+(a parabola has *e = 1*). Angles in **degrees**, distances in **AU**. Returns an `OrbitPosition`.
+
+**`BarkerEquation`** — solves `s³ + 3s − W = 0` for `s = tan(v/2)`:
+
+| Method | Returns |
+|---|---|
+| `wCoefficient(q, t−T)` | `W` (26.1) |
+| `solveTrueAnomalyParameter(W)` | `s` — recommended (iteration 26.4) |
+| `solveTrueAnomalyParameterByIteration(W)` / `…ClosedForm(W)` | `s` (26.4 / 26.5) |
+| `trueAnomalyAndRadius(s, q)` | `{v, r}` (26.2) |
+
+**`ParabolicMotion`** — `ParabolicElements(q, i, ω, Ω, T)`, `T` = perihelion-passage JD:
+
+| Method | Returns |
+|---|---|
+| `geocentricPosition(el, t−T, X, Y, Z, ε)` | `OrbitPosition`, Sun X/Y/Z same equinox |
+| `geocentricPosition(engine, jd, el, equinox, ε)` | as above, Sun from Ch. 19 |
+| `lightTimeCorrected(engine, jd, el, equinox, ε)` | astrometric place, light-time (25.10) |
+
+```java
+EphemerisEngine engine = new EphemerisEngineImpl();
+
+// Comet Kohler (1977m), 1977 Sep 29.0 ET (book Example 26.a), elements at equinox 1950.0:
+ParabolicElements kohler = new ParabolicElements(
+        0.990662, 48.7196, 163.4799, 181.8175, /*perihelion JD*/ 2443458.0659);
+OrbitPosition p = ParabolicMotion.lightTimeCorrected(
+        engine, 2443415.5, kohler, 1950.0, 23.4457889);   // α/δ referred to 1950.0
+// α ≈ 244.62°, δ ≈ +20.45°
+
+double mag = EllipticMotion.cometTotalMagnitude(6.0, p.distanceToEarthAU(), p.radiusVectorAU(), 10.0);
+```
+
+> **HOT TIP:** the root `s` has the **same sign as `t − T`** — negative before perihelion. As with
+> Ch. 25, keep the elements and the Sun on the **same equinox** and pass the matching obliquity
+> (`23.4457889°` for 1950.0). Positions are **geometric** (+ optional light-time); nutation &
+> aberration (Ch. 16) are the caller's. Build Julian Days carefully — an off-by-N-days slip is a
+> ~N° Sun error in the convenience path; verify `t − T` against the book.
+
+---
+
+## 19. Constants — `Constants`
 
 | Constant | Value |
 |---|---|
@@ -570,7 +614,7 @@ OrbitPosition p = EllipticMotion.secondMethodLightTimeCorrected(
 
 ---
 
-## 19. BUILD & DEPENDENCIES
+## 20. BUILD & DEPENDENCIES
 
 ```
 mvn clean verify            # compile + run the 82-test suite + build the jar
@@ -583,7 +627,7 @@ mvn clean verify            # compile + run the 82-test suite + build the jar
 
 ---
 
-## 20. END-TO-END EXAMPLE
+## 21. END-TO-END EXAMPLE
 
 ```java
 // Where is Saturn in the sky from Uccle on 1978-11-13 at 04:34 UT?

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.nzv.astro</groupId>
 	<artifactId>meeus-engine</artifactId>
-	<version>1.8.0</version>
+	<version>1.9.0</version>
 	<packaging>jar</packaging>
 
 	<name>EphemerisEngine</name>

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/BarkerEquation.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/BarkerEquation.java
@@ -1,0 +1,110 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static java.lang.Math.atan;
+import static java.lang.Math.cbrt;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.tan;
+
+/**
+ * Solver for <i>Barker's equation</i>, {@code s^3 + 3s - W = 0} (26.3), which
+ * gives the motion of a body in a parabolic orbit in chapter 26 of Jean Meeus'
+ * <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * For a parabolic orbit the eccentricity is exactly 1, the semimajor axis and
+ * period are infinite and the mean motion is zero, so the equation of Kepler
+ * does not apply. Instead, the quantity {@code s = tan(v/2)} (with {@code v} the
+ * true anomaly) is the single real root of the cubic (26.3), whose coefficient
+ * {@code W} (26.1) is built from the perihelion distance and the time since
+ * perihelion. The root has the same sign as {@code t - T}: negative before
+ * perihelion, positive after.
+ * <p>
+ * The chapter gives two ways to obtain {@code s}: an iteration (26.4), which the
+ * author prefers because it works without any difficulty, and a closed form
+ * (26.5) after Bauschinger. Both are provided here; the iteration is the
+ * recommended default.
+ *
+ * @see ParabolicMotion
+ */
+public final class BarkerEquation {
+
+	/** Coefficient of formula (26.1): {@code W = 0.0364911624 (t - T) / (q*sqrt(q))}. */
+	public static final double W_CONSTANT = 0.0364911624d;
+
+	private BarkerEquation() {
+		// Utility class: no instances.
+	}
+
+	/**
+	 * The coefficient {@code W} of Barker's equation, formula (26.1).
+	 *
+	 * @param perihelionDistanceAU the perihelion distance {@code q}, in AU.
+	 * @param daysSincePerihelion the time since perihelion {@code t - T}, in days
+	 *            (negative before perihelion).
+	 * @return the coefficient {@code W}.
+	 */
+	public static double wCoefficient(double perihelionDistanceAU, double daysSincePerihelion) {
+		return W_CONSTANT * daysSincePerihelion
+				/ (perihelionDistanceAU * sqrt(perihelionDistanceAU));
+	}
+
+	/**
+	 * Solves Barker's equation for {@code s = tan(v/2)} — the recommended method,
+	 * the iteration (26.4).
+	 *
+	 * @param w the coefficient {@code W} (see {@link #wCoefficient}).
+	 * @return the real root {@code s = tan(v/2)}.
+	 */
+	public static double solveTrueAnomalyParameter(double w) {
+		return solveTrueAnomalyParameterByIteration(w);
+	}
+
+	/**
+	 * Solves Barker's equation by the iteration (26.4),
+	 * {@code s' = (2 s^3 + W) / (3 (s^2 + 1))}, starting from {@code s = 0} and
+	 * repeating until the value is stable. This is the author's preferred method.
+	 *
+	 * @param w the coefficient {@code W}.
+	 * @return the real root {@code s = tan(v/2)}.
+	 */
+	public static double solveTrueAnomalyParameterByIteration(double w) {
+		double s = 0d;
+		for (int iteration = 0; iteration < 100; iteration++) {
+			double next = (2d * s * s * s + w) / (3d * (s * s + 1d));
+			if (Math.abs(next - s) < 1e-12d) {
+				return next;
+			}
+			s = next;
+		}
+		return s;
+	}
+
+	/**
+	 * Solves Barker's equation in closed form (26.5), after Bauschinger:
+	 * {@code tan beta = 2/W}, {@code tan gamma = cbrt(tan(beta/2))},
+	 * {@code s = 2 / tan(2 gamma)}. The cube root is taken of a possibly negative
+	 * quantity, which {@link Math#cbrt} handles directly.
+	 *
+	 * @param w the coefficient {@code W}.
+	 * @return the real root {@code s = tan(v/2)}.
+	 */
+	public static double solveTrueAnomalyParameterClosedForm(double w) {
+		double beta = atan(2d / w);                                // tan beta = 2/W
+		double gamma = atan(cbrt(tan(beta / 2d)));                 // tan gamma = cbrt(tan(beta/2))
+		return 2d / tan(2d * gamma);                               // s = 2 / tan(2 gamma)
+	}
+
+	/**
+	 * The true anomaly {@code v} (degrees) and radius vector {@code r} (AU) from
+	 * the root {@code s} and the perihelion distance, formula (26.2):
+	 * {@code v = 2 atan(s)}, {@code r = q (1 + s^2)}.
+	 *
+	 * @param s the root {@code s = tan(v/2)}.
+	 * @param perihelionDistanceAU the perihelion distance {@code q}, in AU.
+	 * @return {@code {v, r}} — true anomaly in degrees and radius vector in AU.
+	 */
+	public static double[] trueAnomalyAndRadius(double s, double perihelionDistanceAU) {
+		double v = Math.toDegrees(2d * atan(s));
+		double r = perihelionDistanceAU * (1d + s * s);
+		return new double[] { v, r };
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/EllipticMotion.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/EllipticMotion.java
@@ -1,7 +1,6 @@
 package com.nzv.astro.ephemeris.orbit;
 
 import static java.lang.Math.asin;
-import static java.lang.Math.acos;
 import static java.lang.Math.atan2;
 import static java.lang.Math.cos;
 import static java.lang.Math.hypot;
@@ -164,8 +163,8 @@ public final class EllipticMotion {
 		double delta = geo[2];
 		double r = lbr[2];
 		EquatorialCoordinates eq = eclipticToEquatorial(lambda, beta, obliquityDegrees);
-		double elongation = elongation(r, delta, sunRadiusVectorAU);
-		double phase = phaseAngle(r, delta, sunRadiusVectorAU);
+		double elongation = GeocentricReduction.elongation(r, delta, sunRadiusVectorAU);
+		double phase = GeocentricReduction.phaseAngle(r, delta, sunRadiusVectorAU);
 		return new OrbitPosition(eq, r, delta, elongation, phase);
 	}
 
@@ -242,11 +241,9 @@ public final class EllipticMotion {
 				elements.semiMajorAxisAU());
 		double v = vr[0];
 		double r = vr[1];
-		double omega = elements.argumentOfPerihelionDegrees();
-		double x = r * g[0] * sin(toRadians(g[3] + omega + v));
-		double y = r * g[1] * sin(toRadians(g[4] + omega + v));
-		double z = r * g[2] * sin(toRadians(g[5] + omega + v));
-		return new double[] { x, y, z, r };
+		double[] xyz = GeocentricReduction.heliocentricRectangular(g,
+				elements.argumentOfPerihelionDegrees(), v, r);
+		return new double[] { xyz[0], xyz[1], xyz[2], r };
 	}
 
 	/**
@@ -261,21 +258,7 @@ public final class EllipticMotion {
 			double sunX, double sunY, double sunZ, double obliquityDegrees) {
 		double[] xyzr = heliocentricEquatorialRectangular(elements, meanAnomalyDegrees,
 				obliquityDegrees);
-		double x = xyzr[0];
-		double y = xyzr[1];
-		double z = xyzr[2];
-		double r = xyzr[3];
-		double xi = sunX + x;
-		double eta = sunY + y;
-		double zeta = sunZ + z;
-		double alpha = normalize(toDegrees(atan2(eta, xi)));                       // (25.15)
-		double delta = sqrt(xi * xi + eta * eta + zeta * zeta);
-		double dec = toDegrees(asin(zeta / delta));
-		double sunR = sqrt(sunX * sunX + sunY * sunY + sunZ * sunZ);
-		double elongation = elongation(r, delta, sunR);
-		double phase = phaseAngle(r, delta, sunR);
-		return new OrbitPosition(new EquatorialCoordinates(alpha, dec), r, delta, elongation,
-				phase);
+		return GeocentricReduction.reduce(xyzr[0], xyzr[1], xyzr[2], xyzr[3], sunX, sunY, sunZ);
 	}
 
 	/**
@@ -385,28 +368,6 @@ public final class EllipticMotion {
 		double dec = toDegrees(asin(
 				sin(beta) * cos(eps) + cos(beta) * sin(eps) * sin(lambda)));       // (8.4)
 		return new EquatorialCoordinates(alpha, dec);
-	}
-
-	/** Elongation psi from the Sun, page 120: cos psi = (R^2 + D^2 - r^2)/(2 R D). */
-	private static double elongation(double r, double delta, double sunR) {
-		double cosPsi = (sunR * sunR + delta * delta - r * r) / (2d * sunR * delta);
-		return toDegrees(acos(clamp(cosPsi)));
-	}
-
-	/** Phase angle (Sun-body-Earth), page 120: cos beta = (r^2 + D^2 - R^2)/(2 r D). */
-	private static double phaseAngle(double r, double delta, double sunR) {
-		double cosBeta = (r * r + delta * delta - sunR * sunR) / (2d * r * delta);
-		return toDegrees(acos(clamp(cosBeta)));
-	}
-
-	private static double clamp(double cosine) {
-		if (cosine > 1d) {
-			return 1d;
-		}
-		if (cosine < -1d) {
-			return -1d;
-		}
-		return cosine;
 	}
 
 	private static double normalize(double degrees) {

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/GeocentricReduction.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/GeocentricReduction.java
@@ -1,0 +1,118 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static java.lang.Math.acos;
+import static java.lang.Math.asin;
+import static java.lang.Math.atan2;
+import static java.lang.Math.sin;
+import static java.lang.Math.sqrt;
+import static java.lang.Math.toDegrees;
+import static java.lang.Math.toRadians;
+
+import com.nzv.astro.ephemeris.coordinate.impl.EquatorialCoordinates;
+
+/**
+ * The geocentric-reduction tail shared by the second method of chapter 25
+ * (elliptic motion) and chapter 26 (parabolic motion). Both chapters, once they
+ * have the body's true anomaly {@code v} and radius vector {@code r}, finish in
+ * exactly the same way: form the heliocentric rectangular equatorial coordinates
+ * with the per-orbit Gaussian constants (25.14), add the Sun's geocentric
+ * rectangular equatorial coordinates and read off the right ascension,
+ * declination and Earth distance (25.15), then the elongation and phase angle
+ * (page 120). This class holds that common machinery so neither chapter
+ * duplicates it.
+ * <p>
+ * Package-private: an internal helper of the {@code orbit} package, not part of
+ * the public API.
+ */
+final class GeocentricReduction {
+
+	private GeocentricReduction() {
+		// Utility class: no instances.
+	}
+
+	/**
+	 * Heliocentric rectangular equatorial coordinates of the body, formula
+	 * (25.14), from the per-orbit Gaussian constants, the argument of perihelion,
+	 * the true anomaly and the radius vector.
+	 *
+	 * @param gaussian the constants {@code {a, b, c, A, B, C}} from
+	 *            {@link EllipticMotion#gaussianConstants}.
+	 * @param argPerihelionDegrees the argument of perihelion {@code omega}, deg.
+	 * @param trueAnomalyDegrees the true anomaly {@code v}, in degrees.
+	 * @param radiusVectorAU the radius vector {@code r}, in AU.
+	 * @return {@code {x, y, z}} in AU.
+	 */
+	static double[] heliocentricRectangular(double[] gaussian, double argPerihelionDegrees,
+			double trueAnomalyDegrees, double radiusVectorAU) {
+		double a = gaussian[0];
+		double b = gaussian[1];
+		double c = gaussian[2];
+		double A = gaussian[3];
+		double B = gaussian[4];
+		double C = gaussian[5];
+		double x = radiusVectorAU * a * sin(toRadians(A + argPerihelionDegrees + trueAnomalyDegrees));
+		double y = radiusVectorAU * b * sin(toRadians(B + argPerihelionDegrees + trueAnomalyDegrees));
+		double z = radiusVectorAU * c * sin(toRadians(C + argPerihelionDegrees + trueAnomalyDegrees));
+		return new double[] { x, y, z };
+	}
+
+	/**
+	 * Combines the body's heliocentric rectangular equatorial coordinates with
+	 * the Sun's geocentric rectangular equatorial coordinates (referred to the
+	 * same equinox) to obtain the geocentric position, formula (25.15), plus the
+	 * elongation and phase angle of page 120.
+	 *
+	 * @param x body heliocentric equatorial X, in AU.
+	 * @param y body heliocentric equatorial Y, in AU.
+	 * @param z body heliocentric equatorial Z, in AU.
+	 * @param radiusVectorAU the radius vector {@code r}, in AU.
+	 * @param sunX the Sun's geocentric equatorial X, in AU.
+	 * @param sunY the Sun's geocentric equatorial Y, in AU.
+	 * @param sunZ the Sun's geocentric equatorial Z, in AU.
+	 * @return the geocentric position, with right ascension/declination referred
+	 *         to the equinox of the inputs.
+	 */
+	static OrbitPosition reduce(double x, double y, double z, double radiusVectorAU, double sunX,
+			double sunY, double sunZ) {
+		double xi = sunX + x;
+		double eta = sunY + y;
+		double zeta = sunZ + z;
+		double alpha = normalizeDegrees(toDegrees(atan2(eta, xi)));                // (25.15)
+		double delta = sqrt(xi * xi + eta * eta + zeta * zeta);
+		double dec = toDegrees(asin(zeta / delta));
+		double sunR = sqrt(sunX * sunX + sunY * sunY + sunZ * sunZ);
+		double elongation = elongation(radiusVectorAU, delta, sunR);
+		double phase = phaseAngle(radiusVectorAU, delta, sunR);
+		return new OrbitPosition(new EquatorialCoordinates(alpha, dec), radiusVectorAU, delta,
+				elongation, phase);
+	}
+
+	/** Elongation psi from the Sun, page 120: cos psi = (R^2 + D^2 - r^2)/(2 R D). */
+	static double elongation(double r, double delta, double sunR) {
+		return toDegrees(acos(clamp((sunR * sunR + delta * delta - r * r) / (2d * sunR * delta))));
+	}
+
+	/** Phase angle (Sun-body-Earth), page 120: cos beta = (r^2 + D^2 - R^2)/(2 r D). */
+	static double phaseAngle(double r, double delta, double sunR) {
+		return toDegrees(acos(clamp((r * r + delta * delta - sunR * sunR) / (2d * r * delta))));
+	}
+
+	/** Normalises an angle in degrees to the range [0, 360). */
+	static double normalizeDegrees(double degrees) {
+		double d = degrees % 360d;
+		if (d < 0d) {
+			d += 360d;
+		}
+		return d;
+	}
+
+	private static double clamp(double cosine) {
+		if (cosine > 1d) {
+			return 1d;
+		}
+		if (cosine < -1d) {
+			return -1d;
+		}
+		return cosine;
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/ParabolicElements.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/ParabolicElements.java
@@ -1,0 +1,43 @@
+package com.nzv.astro.ephemeris.orbit;
+
+/**
+ * The orbital elements of a comet moving in a parabolic orbit, referred to a
+ * standard equinox, as used by chapter 26 of Jean Meeus' <i>Astronomical
+ * Formulae for Calculators</i>.
+ * <p>
+ * A parabolic orbit has eccentricity exactly 1, so there is no semimajor axis
+ * and no mean motion: the body's place along the orbit is fixed entirely by the
+ * perihelion distance {@code q} and the time of perihelion passage {@code T}.
+ * The orientation angles {@code i, omega, Omega} are referred to whatever
+ * standard equinox the caller works in (typically 1950.0); as with the second
+ * method of chapter 25, the engine reduces the Sun's coordinates to that same
+ * equinox, so the resulting right ascension and declination come out referred to
+ * it.
+ * <p>
+ * Angles are in degrees, {@code q} is in astronomical units, and {@code T} is a
+ * Julian Day (Ephemeris Time).
+ *
+ * @param perihelionDistanceAU the perihelion distance {@code q}, in AU.
+ * @param inclinationDegrees the inclination {@code i}, in degrees.
+ * @param argumentOfPerihelionDegrees the argument of perihelion {@code omega},
+ *            in degrees.
+ * @param ascendingNodeLongitudeDegrees the longitude of the ascending node
+ *            {@code Omega}, in degrees.
+ * @param perihelionPassageJulianDay the time of perihelion passage {@code T}, as
+ *            a Julian Day (Ephemeris Time).
+ */
+public record ParabolicElements(double perihelionDistanceAU, double inclinationDegrees,
+		double argumentOfPerihelionDegrees, double ascendingNodeLongitudeDegrees,
+		double perihelionPassageJulianDay) {
+
+	/**
+	 * The time since perihelion {@code t - T}, in days (negative before
+	 * perihelion), for the given instant.
+	 *
+	 * @param julianDay the instant, as a Julian Day (Ephemeris Time).
+	 * @return {@code t - T}, in days.
+	 */
+	public double daysSincePerihelion(double julianDay) {
+		return julianDay - perihelionPassageJulianDay;
+	}
+}

--- a/src/main/java/com/nzv/astro/ephemeris/orbit/ParabolicMotion.java
+++ b/src/main/java/com/nzv/astro/ephemeris/orbit/ParabolicMotion.java
@@ -1,0 +1,117 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import com.nzv.astro.ephemeris.EphemerisEngine;
+
+/**
+ * Geocentric ephemeris of a comet in a parabolic orbit, following chapter 26 of
+ * Jean Meeus' <i>Astronomical Formulae for Calculators</i>.
+ * <p>
+ * The procedure is the second method of chapter 25 with the Kepler solve
+ * replaced by Barker's equation (the {@code e = 1} case): from the perihelion
+ * distance and the time since perihelion it forms the coefficient {@code W}
+ * (26.1), solves {@code s^3 + 3s - W = 0} for {@code s = tan(v/2)}
+ * ({@link BarkerEquation}), obtains the true anomaly and radius vector (26.2),
+ * and then finishes through the very same geocentric reduction as chapter 25 —
+ * the per-orbit Gaussian constants (25.13), the heliocentric rectangular
+ * equatorial coordinates (25.14) and the combination with the Sun (25.15),
+ * shared via {@link GeocentricReduction}.
+ * <p>
+ * The position returned is the comet's <i>geometric</i> position, exactly as the
+ * chapter's worked example 26.a produces it; nutation and aberration (chapter
+ * 16) are left to the caller, and the light-time correction can be applied with
+ * {@link #lightTimeCorrected}. Right ascension and declination are referred to
+ * the elements' standard equinox. All angles are in degrees, distances in AU.
+ */
+public final class ParabolicMotion {
+
+	/**
+	 * The light-time constant (25.10): {@code tau = 0.0057756 * Delta} days.
+	 * Shared with elliptic motion.
+	 */
+	public static final double LIGHT_TIME_CONSTANT = EllipticMotion.LIGHT_TIME_CONSTANT;
+
+	private ParabolicMotion() {
+		// Utility class: no instances.
+	}
+
+	/**
+	 * Full geocentric position of the comet from its elements, the time since
+	 * perihelion, the Sun's geocentric rectangular equatorial coordinates
+	 * {@code X, Y, Z} referred to the same standard equinox, and the obliquity of
+	 * that equinox.
+	 *
+	 * @param elements the parabolic elements.
+	 * @param daysSincePerihelion the time since perihelion {@code t - T}, in days.
+	 * @param sunX the Sun's geocentric equatorial X, in AU.
+	 * @param sunY the Sun's geocentric equatorial Y, in AU.
+	 * @param sunZ the Sun's geocentric equatorial Z, in AU.
+	 * @param obliquityDegrees the obliquity of the elements' equinox, in degrees.
+	 * @return the geocentric position.
+	 */
+	public static OrbitPosition geocentricPosition(ParabolicElements elements,
+			double daysSincePerihelion, double sunX, double sunY, double sunZ,
+			double obliquityDegrees) {
+		double w = BarkerEquation.wCoefficient(elements.perihelionDistanceAU(),
+				daysSincePerihelion);
+		double s = BarkerEquation.solveTrueAnomalyParameter(w);
+		double[] vr = BarkerEquation.trueAnomalyAndRadius(s, elements.perihelionDistanceAU());
+		double v = vr[0];
+		double r = vr[1];
+		double[] gaussian = EllipticMotion.gaussianConstants(
+				elements.ascendingNodeLongitudeDegrees(), elements.inclinationDegrees(),
+				obliquityDegrees);
+		double[] xyz = GeocentricReduction.heliocentricRectangular(gaussian,
+				elements.argumentOfPerihelionDegrees(), v, r);
+		return GeocentricReduction.reduce(xyz[0], xyz[1], xyz[2], r, sunX, sunY, sunZ);
+	}
+
+	/**
+	 * Convenience overload that takes the Sun's rectangular coordinates from the
+	 * engine (chapter 19), reduced to the given standard equinox, and uses the
+	 * elements' time of perihelion passage for the instant.
+	 *
+	 * @param engine the ephemeris engine (chapter 19 Sun).
+	 * @param julianDay the instant, as a Julian Day (Ephemeris Time).
+	 * @param elements the parabolic elements (referred to {@code standardEquinox}).
+	 * @param standardEquinox the standard equinox of the elements (e.g. 1950.0).
+	 * @param obliquityDegrees the obliquity of that equinox.
+	 */
+	public static OrbitPosition geocentricPosition(EphemerisEngine engine, double julianDay,
+			ParabolicElements elements, double standardEquinox, double obliquityDegrees) {
+		double[] sun = engine.sunRectangularEquatorialCoordinates(julianDay, standardEquinox);
+		return geocentricPosition(elements, elements.daysSincePerihelion(julianDay), sun[0], sun[1],
+				sun[2], obliquityDegrees);
+	}
+
+	/**
+	 * As {@link #geocentricPosition(EphemerisEngine, double, ParabolicElements,
+	 * double, double)} but with the light-time correction (25.10) applied: the
+	 * comet is taken at the retarded instant {@code t - tau} while the Sun is kept
+	 * at {@code t}, iterating until {@code tau} is stable. The result is the
+	 * astrometric place; nutation and aberration (chapter 16) are not applied.
+	 *
+	 * @param engine the ephemeris engine (chapter 19 Sun).
+	 * @param julianDay the instant of observation {@code t}, as a Julian Day (ET).
+	 * @param elements the parabolic elements (referred to {@code standardEquinox}).
+	 * @param standardEquinox the standard equinox of the elements.
+	 * @param obliquityDegrees the obliquity of that equinox.
+	 */
+	public static OrbitPosition lightTimeCorrected(EphemerisEngine engine, double julianDay,
+			ParabolicElements elements, double standardEquinox, double obliquityDegrees) {
+		double[] sun = engine.sunRectangularEquatorialCoordinates(julianDay, standardEquinox);
+		double tau = 0d;
+		OrbitPosition position = null;
+		for (int iteration = 0; iteration < 10; iteration++) {
+			double daysSincePerihelion = elements.daysSincePerihelion(julianDay - tau);
+			position = geocentricPosition(elements, daysSincePerihelion, sun[0], sun[1], sun[2],
+					obliquityDegrees);
+			double newTau = LIGHT_TIME_CONSTANT * position.distanceToEarthAU();
+			if (Math.abs(newTau - tau) < 1e-9d) {
+				tau = newTau;
+				break;
+			}
+			tau = newTau;
+		}
+		return position;
+	}
+}

--- a/src/test/java/com/nzv/astro/ephemeris/orbit/ParabolicMotionTest.java
+++ b/src/test/java/com/nzv/astro/ephemeris/orbit/ParabolicMotionTest.java
@@ -1,0 +1,137 @@
+package com.nzv.astro.ephemeris.orbit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.nzv.astro.ephemeris.EphemerisEngine;
+import com.nzv.astro.ephemeris.impl.EphemerisEngineImpl;
+
+/**
+ * Validates the chapter-26 parabolic-motion engine against the chapter's worked
+ * example 26.a (comet Kohler 1977m).
+ * <p>
+ * Two-tier discipline as for chapter 25: the pure geometry is checked against the
+ * book's own printed inputs and intermediates (tight), then the {@code julianDay}
+ * convenience path is checked end-to-end through the library's own Sun (looser,
+ * with the computed value pinned).
+ */
+public class ParabolicMotionTest {
+
+	private static final EphemerisEngine ENGINE = new EphemerisEngineImpl();
+
+	private static final double EQUINOX_1950 = 1950.0d;
+	private static final double OBLIQUITY_1950 = 23.4457889d;
+
+	// Example 26.a — comet Kohler (1977m), 1977 September 29.0 ET (IAUC 3137).
+	// Verified Julian Days: observation 1977 Sep 29.0 = JD 2443415.5; time of
+	// perihelion passage 1977 Nov 10.5659 = JD 2443458.0659; hence t - T = -42.5659.
+	private static final double OBSERVATION_JD = 2443415.5d;
+	private static final double PERIHELION_JD = 2443458.0659d;
+	private static final double DAYS_SINCE_PERIHELION = -42.5659d;
+
+	private static ParabolicElements kohler() {
+		return new ParabolicElements(0.990662d, 48.7196d, 163.4799d, 181.8175d, PERIHELION_JD);
+	}
+
+	/* ===================== Barker's equation (26.1–26.5) ==================== */
+
+	@Test
+	public void wCoefficientReproducesExample26a() {
+		double w = BarkerEquation.wCoefficient(0.990662d, DAYS_SINCE_PERIHELION);
+		assertEquals(-1.5752927d, w, 1e-6d);
+	}
+
+	@Test
+	public void barkerIterationReproducesExample26a() {
+		double w = BarkerEquation.wCoefficient(0.990662d, DAYS_SINCE_PERIHELION);
+		double s = BarkerEquation.solveTrueAnomalyParameterByIteration(w);
+		assertEquals(-0.4866743d, s, 5e-7d);
+	}
+
+	@Test
+	public void barkerClosedFormMatchesIterationAndBook() {
+		double w = BarkerEquation.wCoefficient(0.990662d, DAYS_SINCE_PERIHELION);
+		double sIteration = BarkerEquation.solveTrueAnomalyParameterByIteration(w);
+		double sClosedForm = BarkerEquation.solveTrueAnomalyParameterClosedForm(w);
+		assertEquals("closed form vs book", -0.4866743d, sClosedForm, 5e-7d);
+		assertEquals("closed form vs iteration", sIteration, sClosedForm, 1e-9d);
+	}
+
+	@Test
+	public void trueAnomalyAndRadiusReproduceExample26a() {
+		double w = BarkerEquation.wCoefficient(0.990662d, DAYS_SINCE_PERIHELION);
+		double s = BarkerEquation.solveTrueAnomalyParameter(w);
+		double[] vr = BarkerEquation.trueAnomalyAndRadius(s, 0.990662d);
+		assertEquals("v", -51.90199d, vr[0], 5e-5d);
+		assertEquals("r", 1.2253022d, vr[1], 5e-7d);
+	}
+
+	@Test
+	public void barkerRootHasSameSignAsTimeSincePerihelion() {
+		double before = BarkerEquation.solveTrueAnomalyParameter(
+				BarkerEquation.wCoefficient(0.990662d, -10d));
+		double after = BarkerEquation.solveTrueAnomalyParameter(
+				BarkerEquation.wCoefficient(0.990662d, +10d));
+		assertTrue("negative before perihelion", before < 0d);
+		assertTrue("positive after perihelion", after > 0d);
+	}
+
+	/* ===================== Geometry against the book's Sun ================== */
+
+	@Test
+	public void geocentricPositionReproducesExample26a() {
+		// Sun's geocentric rectangular equatorial coordinates from the book (1950.0).
+		OrbitPosition p = ParabolicMotion.geocentricPosition(kohler(), DAYS_SINCE_PERIHELION,
+				-0.9973057d, -0.0857667d, -0.0371837d, OBLIQUITY_1950);
+		assertEquals("alpha", 244.622064d, p.rightAscensionDegrees(), 1e-3d);
+		assertEquals("delta", 20.4517d, p.declinationDegrees(), 2e-3d);
+		assertEquals("Delta", 1.3025435d, p.distanceToEarthAU(), 5e-7d);
+		assertEquals("r", 1.2253022d, p.radiusVectorAU(), 5e-7d);
+		assertEquals("psi", 62.66d, p.elongationDegrees(), 1e-2d);
+	}
+
+	@Test
+	public void cometMagnitudeReproducesExample26a() {
+		// magnitude = 6.0 + 5 log Delta + 10 log r  (g = 6.0, kappa = 10).
+		double m = EllipticMotion.cometTotalMagnitude(6.0d, 1.3025435d, 1.2253022d, 10.0d);
+		assertEquals("magnitude", 7.5d, m, 5e-2d);
+	}
+
+	/* ===================== julianDay + light-time path ===================== */
+
+	@Test
+	public void geocentricPositionFromEngineApproximatesExample26a() {
+		// Sun from chapter 19 + light-time. The comet is at Delta = 1.30 AU, so the
+		// known ~3e-5 AU equinox-reduction residual is only weakly amplified and the
+		// agreement with the book is good; the value is pinned as the regression anchor.
+		OrbitPosition p = ParabolicMotion.lightTimeCorrected(ENGINE, OBSERVATION_JD, kohler(),
+				EQUINOX_1950, OBLIQUITY_1950);
+		assertEquals("alpha vs book", 244.622064d, p.rightAscensionDegrees(), 8e-3d);
+		assertEquals("delta vs book", 20.4517d, p.declinationDegrees(), 8e-3d);
+		// Regression anchors (engine Sun + light-time).
+		assertEquals("alpha pinned", 244.617887d, p.rightAscensionDegrees(), 5e-4d);
+		assertEquals("delta pinned", 20.451748d, p.declinationDegrees(), 5e-4d);
+	}
+
+	@Test
+	public void lightTimeShiftsThePositionSlightly() {
+		double[] sun = ENGINE.sunRectangularEquatorialCoordinates(OBSERVATION_JD, EQUINOX_1950);
+		OrbitPosition geometric = ParabolicMotion.geocentricPosition(kohler(),
+				kohler().daysSincePerihelion(OBSERVATION_JD), sun[0], sun[1], sun[2],
+				OBLIQUITY_1950);
+		OrbitPosition corrected = ParabolicMotion.lightTimeCorrected(ENGINE, OBSERVATION_JD,
+				kohler(), EQUINOX_1950, OBLIQUITY_1950);
+		double shift = Math.abs(corrected.rightAscensionDegrees()
+				- geometric.rightAscensionDegrees());
+		assertTrue("light-time produces a non-zero shift", shift > 0d);
+		assertTrue("light-time shift is small", shift < 0.05d);
+	}
+
+	@Test
+	public void daysSincePerihelionIsTimeMinusPerihelion() {
+		assertEquals(DAYS_SINCE_PERIHELION, kohler().daysSincePerihelion(OBSERVATION_JD), 1e-9d);
+		assertEquals(0d, kohler().daysSincePerihelion(PERIHELION_JD), 1e-9d);
+	}
+}


### PR DESCRIPTION
Add the parabolic-motion engine (Ch 26) — geocentric positions of comets in parabolic orbits — and factor out the geocentric-reduction tail now shared with Ch 25. Algorithm-bound and table-free, like the elliptic engine.

A parabola has e = 1 (infinite semimajor axis and period, zero mean motion), so the equation of Kepler does not apply; the position parameter s = tan(v/2) is instead the real root of Barker's equation. Otherwise the chapter is the Ch 25 second method verbatim: once v and r are known, the reduction continues through formulae (25.13)-(25.15).

New classes in com.nzv.astro.ephemeris.orbit:

* BarkerEquation - solves s^3 + 3s - W = 0 for s = tan(v/2): the coefficient W (26.1), both solving methods of the chapter (the iteration 26.4, recommended default, and the closed form 26.5 after Bauschinger), and the true anomaly / radius vector (26.2). The parabolic sibling of KeplerEquation. Math.cbrt takes the real cube root of a negative number directly, so the closed form needs none of the book's HP-67 sign tricks.
* ParabolicElements (record) - q, i, omega, Omega, T (perihelion distance, orientation, time of perihelion passage); daysSincePerihelion(jd).
* ParabolicMotion - geocentricPosition(...) (static and julianDay overloads) and lightTimeCorrected(...), reusing the Ch 19 Sun. Comet total magnitude (25.16) is already on EllipticMotion.

Internal refactor (behaviour-preserving): the {x,y,z,r} + Sun -> OrbitPosition tail (25.14/25.15 + elongation/phase) is extracted into a package-private GeocentricReduction helper and reused by both the elliptic second method and the parabolic engine. The Ch 25 tests are unchanged and still pass.

Validation (10 new tests, suite 121 -> 131):
* Example 26.a (comet Kohler 1977m) - W, the root s by both solving methods, v, r, alpha/delta (1950.0), Delta, elongation and the comet magnitude all reproduce the book to printed precision against its printed Sun X,Y,Z; through the Ch 19 Sun + light-time the agreement is ~0.004 deg and is pinned.

Positions are geometric plus the light-time correction; nutation and aberration onto a fully apparent place (Ch 16) are left to the caller, as in Ch 25.

Docs: CHANGELOG, REFCARD (new section 18), coverage report (Ch 26 0% -> 95%) and the phased plan (Phase 4 step 2 done) updated; pom 1.8.0 -> 1.9.0.