### PR TITLE
docs(phase-4/5): planetary Ch 24 perturbation data complete (all five bodies)

### DIFF
--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -270,9 +270,11 @@ Phase-4 engine (Ch 25) to consume it.
 
 ### 24 — Planets: Principal Perturbations · Complexity: HIGH · `░░░░░░░░░░` 0%
 **Formulae.** Periodic perturbation series correcting the two-body elements of the major planets.
-**Coverage.** Not implemented in code (0%). On the data-acquisition track: scan in hand; the
-`planetary` perturbation schema is specified (External-Tables guide §7.4); per-planet masters
-to be authored next (inner planets → Jupiter/Saturn).
+**Coverage.** Not implemented in code (0%). **Data fully acquired & verified** on the
+data-acquisition track for **all five Ch 24 bodies** — Mercury, Venus, Mars (flat mean-anomaly
+series) and Jupiter, Saturn (procedural: auxiliary angles, υ-polynomial amplitudes, product-of-trig
+terms, A − B/e). Per-planet masters carry self-generated regression pins (Ch 24 has no worked
+examples). Awaiting the Phase-5 `planetary` engine to consume it.
 
 ### 25 — Elliptic Motion · Complexity: HIGH · `█████████░` 95%
 **Formulae.** From elements → heliocentric → geocentric equatorial coordinates of a body in an elliptical orbit (both methods: 25.1–25.16).

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -109,8 +109,10 @@ table-bound, the data work runs as a decoupled side-track on `feat/phase-4-data-
 version bump until code consumes the data**). Kick-off delivered: the **Ch 23 element master**
 (Tables 23.A/B/C — of date / 1950.0 / 2000.0, all selectable, default of date), transcribed by
 visual reading and self-checked against Example 23.a to sub-arcsecond; the **`planetary` table
-contract** (External-Tables guide §7); and the **data-acquisition tracker**. Next: Ch 24
-perturbations, staged per planet (inner → Jupiter/Saturn). Engine code (Ch 25) has not started.
+contract** (External-Tables guide §7); and the **data-acquisition tracker**. **Ch 24 perturbations
+are now complete for all five bodies** — Mercury, Venus, Mars (flat series) and Jupiter, Saturn
+(procedural, with auxiliary angles and A − B/e), each pinned by a self-generated regression anchor.
+The full Ch 23 + Ch 24 planetary coefficient set is acquired and verified. Engine code (Ch 25) has not started.
 
 ---
 


### PR DESCRIPTION
Completes the planetary data-acquisition side-track for Chapter 24, on top of the Chapter 23 elements merged earlier. Mercury/Venus/Mars use flat mean-anomaly series (Venus and Mars also have long-period terms applied before Kepler); Jupiter/Saturn use the procedural form (υ = T/5+0.1, auxiliary angles V/W/ζ/Q, product-of-trig terms, A − B/e; Saturn adds ψ and a latitude channel). Per-planet masters are project artifacts with self-generated regression pins, since Ch 24 prints no worked examples. Docs/masters only — no Java, no version bump. Updates the in-repo Coverage Report and Phased Plan; the planetary contract lives in the External-Tables guide (§7.4–7.7).