### PR TITLE
docs: reconcile Phased Plan & Coverage Report with current state (v1.…

### DIFF
--- a/EphemerisEngine_Coverage_Report.md
+++ b/EphemerisEngine_Coverage_Report.md
@@ -1,7 +1,7 @@
 # EphemerisEngine vs. *Astronomical Formulae for Calculators* — Chapter-by-Chapter Coverage Report
 
 **Reference book:** Jean Meeus, *Astronomical Formulae for Calculators* (Willmann-Bell) — the **39-chapter edition** used as this project's working reference, ending at chapter 39 (*Linear Regression; Correlation*).
-**Library under review:** `com.nzv.astro:meeus-engine:1.7.0` (the EphemerisEngine project).
+**Library under review:** `com.nzv.astro:meeus-engine:1.9.0` (the EphemerisEngine project).
 
 > **Edition & chapter-numbering note (since 1.6.0).** Earlier revisions of this report numbered the
 > later chapters against the *4th edition* (1988, 43 chapters). The project's working copy is an
@@ -72,8 +72,10 @@
 The library is now a faithful, well-tested implementation of the book's **timekeeping,
 calendar, coordinate and solar-position foundations**, plus precession, interpolation,
 refraction and the common positional utilities (angular separation, photometry,
-rise/transit/set) and the apparent place of a star. It still stops before most of the
-**physical-ephemeris payload**: the planets, comets and eclipses are absent — but the Moon's
+rise/transit/set) and the apparent place of a star. It now also includes an **orbital-motion engine** (Chapters 25–26) giving geocentric positions of
+minor planets and comets from caller-supplied elliptic or parabolic elements. It still stops before
+the remaining **physical-ephemeris payload** — built-in major-planet positions and eclipses are
+absent — but the Moon's
 geocentric position (Chapter 30) is implemented via a table-driven series, the derived Sun/Moon
 phenomena (bright limb 13, illuminated fraction 31, phases 32, equinoxes/solstices 20, rectangular
 solar coordinates 19) are complete, and the equation of time (21) and the correction for parallax
@@ -81,16 +83,16 @@ solar coordinates 19) are complete, and the equation of time (21) and the correc
 
 | Coverage band | Chapters | Count |
 |---|---|---|
-| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 21 Equation of Time · 22 Equation of Kepler · 29 Correction for Parallax · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 37 Stellar Magnitudes | 22 |
+| **Strong (≥ 90%)** | 2 Interpolation · 3 Julian Day · 4 Easter · 5 ET/UT · 6 Observer coords · 7 Sidereal Time · 8 Coordinate Transformation · 9 Angular Separation · 13 Bright Limb · 14 Precession · 15 Nutation · 16 Apparent place of a star · 18 Solar Coordinates · 19 Rectangular Coords of the Sun · 20 Equinoxes and Solstices · 21 Equation of Time · 22 Equation of Kepler · 25 Elliptic Motion · 26 Parabolic Motion · 29 Correction for Parallax · 30 Position of the Moon · 31 Illuminated Fraction · 32 Phases of the Moon · 37 Stellar Magnitudes | 24 |
 | **Partial (10–80%)** | 1 Hints · 39 Linear Regression | 2 |
-| **None (0%)** | 10–12, 17, 23–28, 33–36, 38 | 15 |
+| **None (0%)** | 10–12, 17, 23, 24, 27, 28, 33–36, 38 | 13 |
 
 **Overall functional coverage: about half the book**, now spanning the entire
 foundational arc (Chapters 1–9) plus precession (14), nutation (15), the apparent place of
 a star (16), solar coordinates (18) and rectangular solar coordinates (19), equinoxes/solstices (20),
 the equation of time (21), the equation of Kepler (22), the correction for parallax (29), the position of the Moon (30) and its
 derived phenomena — bright limb (13), illuminated fraction (31) and phases (32) — and stellar
-magnitudes (37), with atmospheric refraction and rising/transit/setting available as supplementary
+magnitudes (37), plus the orbital-motion engine for minor planets and comets (25–26), with atmospheric refraction and rising/transit/setting available as supplementary
 utilities beyond the reference edition.
 
 ---
@@ -265,8 +267,8 @@ chapters of the 39-chapter edition, so excluded from the per-chapter percentages
 **Formulae.** Mean orbital elements of the planets as polynomials in time.
 **Coverage.** Not implemented in code (0%). **Data acquired & verified** on the parallel
 data-acquisition track: master `AFFC-tables-chapter-23.xlsx` holds Tables 23.A/B/C (of date /
-1950.0 / 2000.0, selectable), self-checked against Example 23.a to sub-arcsecond. Awaiting the
-Phase-4 engine (Ch 25) to consume it.
+1950.0 / 2000.0, selectable), self-checked against Example 23.a to sub-arcsecond. The Ch 25 engine (v1.8.0) already consumes
+caller-supplied elements; the Phase-5 wiring will feed these built-in elements into it.
 
 ### 24 — Planets: Principal Perturbations · Complexity: HIGH · `░░░░░░░░░░` 0%
 **Formulae.** Periodic perturbation series correcting the two-body elements of the major planets.
@@ -301,7 +303,7 @@ examples). Awaiting the Phase-5 `planetary` engine to consume it.
 **Applications.** Moon and near-body positions as seen from a specific site; occultation/eclipse timing.
 **Coverage.** Implemented in `ParallaxCorrection`: `parallaxFromDistanceInDegrees`, the rigorous `topocentric` and the non-rigorous `topocentricApproximate`, plus the Moon convenience `moonTopocentricEquatorialCoordinates(jd, observer, height, θ₀)`. Validated on Example 29.a (Mars, both formula sets) and exercised at Moon-scale parallax.
 
-### 30 — Position of the Moon · Complexity: HIGH · `██░░░░░░░░` 20%
+### 30 — Position of the Moon · Complexity: HIGH · `█████████░` 90%
 **Formulae.** Moon's mean elements (L′, M′, F, D, Ω) followed by long periodic series for longitude, latitude, and parallax → geocentric position and distance.
 **Applications.** Phases, eclipses, occultations, the Moon's place in the sky.
 **Coverage.** *Implemented in 1.4.0.* Geocentric longitude, latitude and equatorial horizontal parallax are produced by a table-driven evaluator (`com.nzv.astro.ephemeris.lunar`) reading external CSV coefficient tables for the AFFC-1900 model; `jd`-based conveniences give apparent RA/Dec (nutation + true obliquity of date), geocentric ecliptic coordinates, and the Earth–Moon distance. Validated on Example 30.a (λ and π vs the book; β vs the Astronomical Ephemeris value). The design supports dropping in a higher-precision model as data.

--- a/EphemerisEngine_Phased_Implementation_Plan.md
+++ b/EphemerisEngine_Phased_Implementation_Plan.md
@@ -11,9 +11,9 @@
 | **1 — Enablers & quick wins** | ✅ **DONE (v1.2.0)** | 6, 9, 14, 18, 38, 42 | All shipped with regression tests; 43 → 63 tests. |
 | **2 — The two keystones** | ✅ **Done (v1.4.0)** | 16 ✅, 30 ✅ | Star keystone (16) and Moon keystone (30, table-driven series) both shipped. |
 | **3 — Harvest** | 🟦 In progress — steps 1–2 ✅, 3a ✅ (v1.5.0–v1.7.0) | 13 ✅, 19 ✅, 20 ✅, 21 ✅, 22 ✅, 29 ✅, 31 ✅, 32 ✅ · then 38 | Steps 1–2 and 3a (equation of Kepler) shipped, 82 → 108 tests. Step 3b (binary stars, Ch 38) is the last Harvest item. |
-| **4 — Planets & minor bodies** | 🟦 Committed (Option C); data-acquisition track started | 23–28, 34–36 | Parallel **data-acquisition side-track** live on `feat/phase-4-data-acquisition` (docs/masters only): Ch 23 elements ✅ transcribed & self-checked, Ch 24 perturbations next. See the proposal + data-acquisition tracker. |
-| **4 — Orbital-motion engine & minor bodies** | 🟦 In progress — steps 1–2 ✅ (v1.8.0–v1.9.0) | 25 ✅, 26 ✅ · then 27, 28, 36 | Elliptic (Ch 25) and parabolic/comet (Ch 26) engines shipped, 108 → 131 tests. Algorithm-bound, table-free; runs in parallel with the Ch 23/24 data-acquisition track. |
-| *Deferred* | ⬜ Out of scope (data-bound) | Major-planet data (elements + perturbations) and Phase-5 derived phenomena. |
+| **4 — Orbital-motion engine & minor bodies** | 🟦 In progress — steps 1–2 ✅ (v1.8.0–v1.9.0) | 25 ✅, 26 ✅ · then 27, 28, 36 | Elliptic (Ch 25) and parabolic/comet (Ch 26) engines shipped, 108 → 131 tests. Algorithm-bound, table-free; runs in parallel with the data-acquisition track. |
+| **— Data-acquisition side-track** | 🟦 Ch 23 ✅, Ch 24 ✅ (all 5 bodies) | 23, 24 (+ light 27/28/35/36) | Docs/masters only (no Java, no version bump): Ch 23 elements and Ch 24 perturbations (Mercury–Saturn) transcribed and self-checked/pinned. Feeds the Phase-5 wiring. |
+| **5 — Major planets (data-bound)** | ⬜ Code not started; **data acquired** | 23, 24, 34, 10, 35 | Wire the Ch 23/24 data into a `planetary` engine; then Ch 34, the Ch 10 conjunction capstone, and Ch 35 satellites. |
 
 **What changed in v1.2.0 (Phase 1):**
 - **Ch 18 Solar Coordinates** 25% → **100%** — equation of centre, true/apparent longitude, radius vector, mean obliquity, apparent RA/Dec.
@@ -40,7 +40,7 @@ Chapters positioned by implementation effort against value (with the Moon and st
 | | **Low effort** | **High effort** |
 |---|---|---|
 | **High value** | **Quick wins** — 18 Solar coordinates ✅ · 9 Angular separation ✅ · 42 Rising/transit/setting ✅ · 38 Stellar magnitudes ✅ · 6 Observer coordinates ✅ · 14 Precession ✅ | **Big bets** — 30 Position of the Moon ★★ ✅ · 16 Apparent place of a star ★★ ✅ · 33 Eclipses |
-| **Low value** | **Fill-ins** — 31 Illuminated fraction ✅ · 32 Phases of the Moon ✅ · 13 Bright-limb angle ✅ · 29 Parallax ✅ · 21 Equation of time ✅ | **Defer** — 38 Binary stars · 22 Equation of Kepler · 23+ Planetary suite (Ch 23–28, 34–36) |
+| **Low value** | **Fill-ins** — 31 Illuminated fraction ✅ · 32 Phases of the Moon ✅ · 13 Bright-limb angle ✅ · 29 Parallax ✅ · 21 Equation of time ✅ | **Defer** — 38 Binary stars · 22 Equation of Kepler ✅ · 23+ Planetary suite (engine 25 ✅/26 ✅; data 23 ✅/24 ✅) |
 
 ★★ = the two keystones.
 
@@ -95,10 +95,10 @@ With Phase 3 effectively complete (only Ch 38 remains) and the Kepler solver (Ch
 planetary suite is no longer deferred: it proceeds along **Option C** of the *Planets & Minor
 Bodies Plan Proposal* — two lanes sharing one engine:
 
-- **Phase 4 — Orbital-motion engine & minor bodies** *(algorithm-bound; needs no tables)*. Ch 25
-  elliptic engine + Ch 26 parabolic/comets, driven by **caller-supplied elements** and validated on
-  the book's own worked intermediates; plus light derived chapters (Ch 27/28/36). Ships fast,
-  independent of any data.
+- **Phase 4 — Orbital-motion engine & minor bodies** *(algorithm-bound; needs no tables)* — **steps 1–2 shipped**.
+  Ch 25 elliptic engine (v1.8.0) and Ch 26 parabolic/comet engine (v1.9.0), driven by
+  **caller-supplied elements** and validated on the book's own worked intermediates; the light
+  derived chapters (Ch 27/28/36) remain. Detailed in the Phase 4 section below.
 - **Phase 5 — Major planets & planet-derived phenomena** *(data-bound)*. Ch 23 built-in elements →
   Ch 24 perturbations (on a `planetary` table package mirroring `lunar`) → Ch 34 + conjunction
   capstone; Ch 35 Galilean satellites independent.
@@ -112,7 +112,7 @@ visual reading and self-checked against Example 23.a to sub-arcsecond; the **`pl
 contract** (External-Tables guide §7); and the **data-acquisition tracker**. **Ch 24 perturbations
 are now complete for all five bodies** — Mercury, Venus, Mars (flat series) and Jupiter, Saturn
 (procedural, with auxiliary angles and A − B/e), each pinned by a self-generated regression anchor.
-The full Ch 23 + Ch 24 planetary coefficient set is acquired and verified. Engine code (Ch 25) has not started.
+The full Ch 23 + Ch 24 planetary coefficient set is acquired and verified. The Ch 25 engine that will consume it is already shipped (v1.8.0); what remains is the **Phase-5 wiring** that feeds the built-in elements and perturbations into it.
 
 ---
 
@@ -133,7 +133,7 @@ The keystone here is **Chapter 25 (Elliptic Motion)**: it turns orbital elements
 
 **Effort is dominated by data entry and verification, not algorithm design.** The lunar and solar series are long coefficient tables that must be transcribed exactly. Budget the time accordingly, and lean on the fact that Meeus prints a fully worked numerical example for nearly every chapter.
 
-**Make each chapter regression-proof before moving on.** The library ships a 108-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
+**Make each chapter regression-proof before moving on.** The library ships a 131-test suite built around canonical dates like `1978.1113`. The discipline that makes this plan low-risk is adding each chapter's book example as a regression test *before* moving to the next, so a transcription slip in one coefficient surfaces immediately rather than three chapters later. Phase 1 followed this discipline: every new chapter landed with its worked example (or an independent physical/round-trip check) as a test.
 
 ---
 
@@ -144,6 +144,6 @@ The keystone here is **Chapter 25 (Elliptic Motion)**: it turns orbital elements
 | **1** | Enablers & quick wins | 6, 9, 14, 18, 38, 42 | Low–medium | ✅ Done (v1.2.0) | The substrate for both keystones |
 | **2** | The two keystones | 16 ✅, 30 ✅ | High | ✅ Done (v1.4.0) | Both priority tracks' hard core |
 | **3** | Harvest | 13 ✅ 19 ✅ 20 ✅ 21 ✅ 22 ✅ 29 ✅ 31 ✅ 32 ✅ · then 38 | Low (post-keystone) | 🟦 Steps 1–2, 3a done (v1.5.0–v1.7.0) | The derived Moon and star phenomena |
-| **4** | Data acquisition | Planets & minor bodies (Option C) | 23–28, 34–36 | L (engine) + XL (Ch 24 data) | 🟦 Committed; data track started | Positions of comets, minor planets, and the major planets |
 | **4** | Orbital-motion engine | 25 ✅ 26 ✅ · then 27, 28, 36 | Medium (algorithm-bound) | 🟦 Steps 1–2 done (v1.8.0–v1.9.0) | Positions of comets & minor planets from elements |
-| *Phase 5* | Major planets (data-bound) | 23, 24, 34, 10 | High | ⬜ | Built-in major-planet positions; gated on data acquisition |
+| **—** | Data-acquisition side-track | 23, 24 (+ light 27/28/35/36) | XL (Ch 24 data) | 🟦 Ch 23 ✅, Ch 24 ✅ (5 bodies) | The Phase-5 built-in major-planet positions |
+| **5** | Major planets (data-bound) | 23, 24, 34, 10, 35 | High | ⬜ Code not started; **data acquired** | Built-in major-planet positions |


### PR DESCRIPTION
…9.0)

The planning docs had drifted: the orbital-motion engine (Ch 25 v1.8.0, Ch 26 v1.9.0) shipped and the planetary data-acquisition side-track completed Ch 23 + Ch 24, but the Plan/Coverage still showed stale, partly contradictory status. This commit makes both reflect the current state precisely.

Phased Implementation Plan:
  - Progress tracker: drop the stale "Ch 24 next" data row and the malformed "Deferred" row; show Phase 4 engine (steps 1-2 shipped), the data-acquisition side-track (Ch 23 + Ch 24 complete, all 5 bodies), and a proper Phase 5 (data-bound) row.
  - Phase 4/5 Option-C overview: engine steps 1-2 described as shipped; the stale "Engine code (Ch 25) has not started" replaced by the accurate Phase-5-wiring-remains statement.
  - Effort/Value matrix: Kepler (22) and the planetary engine/data marked done.
  - Test count corrected 108 -> 131; phase-summary table rows de-duplicated.

Coverage Report:
  - Library version 1.7.0 -> 1.9.0.
  - Executive summary now notes the orbital-motion engine (minor planets & comets from elements); only built-in major planets and eclipses remain.
  - Coverage bands: 25 & 26 moved into Strong (>=90%); counts 22->24, 15->13; the "None" range no longer lists 25-26.
  - Fixed the Ch 30 detail header (20% -> 90%) to match the overview/summary.
  - Ch 23 note: the Ch 25 engine already consumes elements; Phase-5 wiring pends.

Docs only; no code or version change.